### PR TITLE
docs: Remove LSIF reference.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -6,7 +6,7 @@ const baseUrl = "/scip-java/";
 
 const siteConfig = {
   title: "scip-java",
-  tagline: "Java indexer for the Language Server Index Format (SCIP)",
+  tagline: "Java indexer for the SCIP Code Intelligence Protocol",
   url: "https://sourcegraph.github.io/scip-java",
   baseUrl: baseUrl,
 


### PR DESCRIPTION
Right now, the [home page](https://sourcegraph.github.io/scip-java/) shows:

![Language Server Index Format (SCIP)](https://user-images.githubusercontent.com/93103176/170716149-5753850a-e726-4230-8134-2ea03e351cef.png)

### Test plan

n/a