### PR TITLE
Include missing `--add-exports` flags for Java 9+ Gradle builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
         # os: [windows-latest, ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,18 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on:  ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
         # os: [windows-latest, ubuntu-latest]
         os: [ubuntu-latest]
+        java: [8, 17]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: ${{ matrix.java }}
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.13.1"

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleBuildTool.scala
@@ -126,9 +126,8 @@ class GradleBuildTool(index: IndexCommand) extends BuildTool("Gradle", index) {
   }
 
   private def initScript(toolchains: GradleJavaToolchains, tmp: Path): Path = {
-    val executableJavacPath = toolchains.executableJavacPath()
     val executable =
-      executableJavacPath match {
+      toolchains.executableJavacPath() match {
         case Some(path) =>
           s"options.forkOptions.executable = '$path'"
         case None =>
@@ -161,7 +160,6 @@ class GradleBuildTool(index: IndexCommand) extends BuildTool("Gradle", index) {
           |      tasks.withType(JavaCompile) {
           |        options.fork = true
           |        options.incremental = false
-          |        System.out.println("JAVA VERSION " + System.getProperty("java.version"))
           |        $executable
           |      }
           |    }

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleJavaCompiler.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleJavaCompiler.scala
@@ -27,7 +27,12 @@ case class GradleJavaCompiler(languageVersion: String, javacPath: Path) {
       pluginPath: Path
   ): Path = {
     val home = tmp.resolve(s"1.$languageVersion")
-    val javac = Embedded.customJavac(index.workingDirectory, targetroot, tmp)
+    val javac = Embedded.customJavac(
+      index.workingDirectory,
+      targetroot,
+      tmp,
+      GradleJavaToolchains.isJavaAtLeast(languageVersion, "17")
+    )
     val agent = Embedded.agentJar(tmp)
     val debugPath = GradleJavaCompiler.debugPath(tmp)
     val javacopts = targetroot.resolve("javacopts.txt")

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MavenBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MavenBuildTool.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 import scala.collection.mutable.ListBuffer
+import scala.util.Properties
 
 import com.sourcegraph.scip_java.Embedded
 import com.sourcegraph.scip_java.commands.IndexCommand
@@ -39,7 +40,10 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
       val executable = Embedded.customJavac(
         index.workingDirectory,
         index.finalTargetroot(defaultTargetroot),
-        tmp
+        tmp,
+        // TODO: infer Java version from `java -version` because it may not
+        // match the Java version that's used by the current process.
+        Properties.isJavaAtLeast(11)
       )
       buildCommand ++=
         List(

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MavenBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MavenBuildTool.scala
@@ -5,7 +5,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 import scala.collection.mutable.ListBuffer
-import scala.util.Properties
 
 import com.sourcegraph.scip_java.Embedded
 import com.sourcegraph.scip_java.commands.IndexCommand
@@ -36,6 +35,7 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
         else {
           "mvn"
         }
+      val start = System.nanoTime()
       val buildCommand = ListBuffer.empty[String]
       val executable = Embedded.customJavac(
         index.workingDirectory,
@@ -43,7 +43,7 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
         tmp,
         // TODO: infer Java version from `java -version` because it may not
         // match the Java version that's used by the current process.
-        Properties.isJavaAtLeast(11)
+        GradleJavaToolchains.isJavaAtLeast(SystemJavaVersion.detect(), "11")
       )
       buildCommand ++=
         List(

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MavenBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MavenBuildTool.scala
@@ -41,8 +41,6 @@ class MavenBuildTool(index: IndexCommand) extends BuildTool("Maven", index) {
         index.workingDirectory,
         index.finalTargetroot(defaultTargetroot),
         tmp,
-        // TODO: infer Java version from `java -version` because it may not
-        // match the Java version that's used by the current process.
         GradleJavaToolchains.isJavaAtLeast(SystemJavaVersion.detect(), "11")
       )
       buildCommand ++=

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/SystemJavaVersion.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/SystemJavaVersion.scala
@@ -5,6 +5,10 @@ import java.nio.file.Files
 import com.sourcegraph.scip_java.Embedded
 
 object SystemJavaVersion {
+  // Returns the output of `System.getProperty("java.version")` from a fresh JVM
+  // instance using the system JVM installation. We can't use this process since
+  // it may be running on a separate JVM process (that's the case when we run
+  // `sbt test` in this build at least).
   def detect(): String = {
     val tmp = Files.createTempDirectory("java-version")
     val jar = Embedded.semanticdbJar(tmp)

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/SystemJavaVersion.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/SystemJavaVersion.scala
@@ -1,0 +1,26 @@
+package com.sourcegraph.scip_java.buildtools
+
+import java.nio.file.Files
+
+import com.sourcegraph.scip_java.Embedded
+
+object SystemJavaVersion {
+  def detect(): String = {
+    val tmp = Files.createTempDirectory("java-version")
+    val jar = Embedded.semanticdbJar(tmp)
+    try {
+      os.proc(
+          "java",
+          "-cp",
+          jar.toString(),
+          "com.sourcegraph.semanticdb_javac.PrintJavaVersion"
+        )
+        .call()
+        .out
+        .text()
+        .trim()
+    } finally {
+      Files.deleteIfExists(jar)
+    }
+  }
+}

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/PrintJavaVersion.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/PrintJavaVersion.java
@@ -1,0 +1,7 @@
+package com.sourcegraph.semanticdb_javac;
+
+public class PrintJavaVersion {
+  public static void main(String[] args) {
+    System.out.print(System.getProperty("java.version"));
+  }
+}

--- a/tests/buildTools/src/test/scala/tests/BaseBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/BaseBuildToolSuite.scala
@@ -18,6 +18,8 @@ import munit.Tag
 import munit.TestOptions
 import os.Shellable
 
+object Java8Only extends munit.Tag("Java8Only")
+
 abstract class BaseBuildToolSuite extends MopedSuite(ScipJava.app) {
   override def environmentVariables: Map[String, String] = sys.env
 
@@ -26,6 +28,14 @@ abstract class BaseBuildToolSuite extends MopedSuite(ScipJava.app) {
   override def munitTestTransforms: List[TestTransform] =
     super.munitTestTransforms ++
       List(
+        new TestTransform(
+          "Java8Only",
+          t =>
+            if (Properties.isJavaAtLeast(9) && t.tags(Java8Only))
+              t.tag(munit.Ignore)
+            else
+              t
+        ),
         new TestTransform(
           "SkipWindows",
           t =>

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -27,7 +27,10 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
   List("latest" -> "implementation", "4.0" -> "compile").foreach {
     case (version, config) =>
       checkBuild(
-        s"basic-$version",
+        if (version == "latest")
+          "basic-latest"
+        else
+          s"basic-$version".tag(Java8Only),
         s"""|/build.gradle
             |apply plugin: 'java'
             |repositories {
@@ -55,7 +58,7 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
 
   List("3.3", "2.2.1").foreach { version =>
     checkBuild(
-      s"legacy-$version",
+      s"legacy-$version".tag(Java8Only),
       s"""|/build.gradle
           |apply plugin: 'java'
           |/src/main/java/Example.java
@@ -90,7 +93,7 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
   )
 
   checkBuild(
-    "toolchains-6.7",
+    "toolchains-6.7".tag(Java8Only),
     """|/build.gradle
        |apply plugin: 'java'
        |java {
@@ -114,7 +117,7 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
   )
 
   checkBuild(
-    "toolchains-6.8",
+    "toolchains-6.8".tag(Java8Only),
     """|/build.gradle
        |apply plugin: 'java'
        |java {
@@ -158,7 +161,7 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
   )
 
   checkBuild(
-    "playframework",
+    "playframework".tag(Java8Only),
     """|/build.gradle
        |plugins {
        |  id 'org.gradle.playframework' version '0.11'
@@ -209,7 +212,7 @@ class GradleBuildToolSuite extends BaseBuildToolSuite {
   )
 
   checkBuild(
-    "checkerframework",
+    "checkerframework".tag(Java8Only),
     """|/build.gradle
        |plugins {
        |    id 'java'


### PR DESCRIPTION
Previously, we didn't include the necessary `--add-exports` flags when
indexing Java 17 builds with Gradle that don't use toolchains. This
commit fixes that bug so we can correctly index repos like
airbytehq/airbyte.

Fixes #463 

### Test plan

Manually tested this by indexing repos locally. We have pretty good infrastructure to write e2e integration tests but this one requires changing the infrastructure because we need to run our test suite itself with Java 17 to reproduce it.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
