### PR TITLE
Link references for fields, fixes #413

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.7.1

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexSemanticdbCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexSemanticdbCommand.scala
@@ -48,7 +48,11 @@ final case class IndexSemanticdbCommand(
 ) extends Command {
   def sourceroot: Path = AbsolutePath.of(app.env.workingDirectory)
   def absoluteTargetroots: List[Path] =
-    targetroot.map(AbsolutePath.of(_, app.env.workingDirectory))
+    if (targetroot.isEmpty)
+      List(sourceroot)
+    else
+      targetroot.map(AbsolutePath.of(_, sourceroot))
+
   def run(): Int = {
     val reporter = new ConsoleScipSemanticdbReporter(app)
     val outputFilename = output.getFileName.toString
@@ -68,7 +72,7 @@ final case class IndexSemanticdbCommand(
         .toList
     val options =
       new ScipSemanticdbOptions(
-        targetroot.map(ts => AbsolutePath.of(ts, sourceroot)).asJava,
+        absoluteTargetroots.asJava,
         AbsolutePath.of(output, sourceroot),
         sourceroot,
         reporter,

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
@@ -10,7 +10,6 @@ import com.sourcegraph.semanticdb_javac.SemanticdbSymbols;
 import com.sourcegraph.Scip;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.*;
 import java.util.*;
@@ -131,7 +130,7 @@ public class ScipSemanticdb {
               Scip.Relationship.newBuilder()
                   .setSymbol(typedSymbol(overriddenSymbol, overriddenSymbolPkg))
                   .setIsImplementation(true)
-                  .setIsReference(SemanticdbSymbols.isMethodOrField(info.getSymbol())));
+                  .setIsReference(supportsReferenceRelationship(info)));
         }
         if (info.hasSignature()) {
           String language =
@@ -284,7 +283,7 @@ public class ScipSemanticdb {
 
       // Overrides
       if (symbolInformation.getOverriddenSymbolsCount() > 0
-          && SemanticdbSymbols.isMethodOrField(symbolInformation.getSymbol())
+          && supportsReferenceRelationship(symbolInformation)
           && occ.getRole() == Role.DEFINITION) {
         List<Integer> overriddenReferenceResultIds =
             new ArrayList<>(symbolInformation.getOverriddenSymbolsCount());
@@ -308,6 +307,17 @@ public class ScipSemanticdb {
     writer.flush();
     options.reporter.processedOneItem();
     return documentId;
+  }
+
+  private static boolean supportsReferenceRelationship(SymbolInformation info) {
+    switch (info.getKind()) {
+      case CLASS:
+      case OBJECT:
+      case PACKAGE_OBJECT:
+        return false;
+      default:
+        return true;
+    }
   }
 
   private Stream<ScipTextDocument> parseTextDocument(Path semanticdbPath) {

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
@@ -131,7 +131,7 @@ public class ScipSemanticdb {
               Scip.Relationship.newBuilder()
                   .setSymbol(typedSymbol(overriddenSymbol, overriddenSymbolPkg))
                   .setIsImplementation(true)
-                  .setIsReference(SemanticdbSymbols.isMethod(info.getSymbol())));
+                  .setIsReference(SemanticdbSymbols.isMethodOrField(info.getSymbol())));
         }
         if (info.hasSignature()) {
           String language =
@@ -284,7 +284,7 @@ public class ScipSemanticdb {
 
       // Overrides
       if (symbolInformation.getOverriddenSymbolsCount() > 0
-          && SemanticdbSymbols.isMethod(symbolInformation.getSymbol())
+          && SemanticdbSymbols.isMethodOrField(symbolInformation.getSymbol())
           && occ.getRole() == Role.DEFINITION) {
         List<Integer> overriddenReferenceResultIds =
             new ArrayList<>(symbolInformation.getOverriddenSymbolsCount());

--- a/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
+++ b/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
@@ -35,8 +35,8 @@ public final class SemanticdbSymbols {
     return !isLocal(symbol);
   }
 
-  public static boolean isMethod(String symbol) {
-    return symbol.endsWith(").");
+  public static boolean isMethodOrField(String symbol) {
+    return symbol.endsWith(".");
   }
 
   /**

--- a/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
+++ b/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbSymbols.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.semanticdb_javac;
 
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Utilities to construct SemanticDB symbols.
@@ -36,7 +35,7 @@ public final class SemanticdbSymbols {
   }
 
   public static boolean isMethodOrField(String symbol) {
-    return symbol.endsWith(".");
+    return symbol.endsWith("#");
   }
 
   /**

--- a/tests/minimized-scala/src/main/scala/minimized/Issue413.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/Issue413.scala
@@ -1,0 +1,9 @@
+package minimized
+
+trait Issue413 {
+  val b: Int
+}
+
+class Issue413Subclass extends Issue413 {
+  override val b = 10
+}

--- a/tests/minimized-scala/src/main/scala/minimized/Issue414.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/Issue414.scala
@@ -1,0 +1,14 @@
+package minimized
+
+object Issue414 {
+  trait A {
+    def b(): Unit
+  }
+  val a: A =
+    new A {
+      override def b(): Unit = {
+        print("Hello")
+      }
+    }
+  println(a.b())
+}

--- a/tests/minimized-scala/src/main/scala/minimized/ReflectiveCall.scala
+++ b/tests/minimized-scala/src/main/scala/minimized/ReflectiveCall.scala
@@ -1,0 +1,12 @@
+package minimized
+
+import scala.language.reflectiveCalls
+
+class ReflectiveCall {
+  // Reproduction for https://github.com/scalameta/scalameta/issues/2788
+  val a =
+    new {
+      val b = 1
+    }
+  println(a.b)
+}

--- a/tests/snapshots/src/main/generated/minimized/Issue413.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue413.scala
@@ -1,0 +1,18 @@
+package minimized
+//      ^^^^^^^^^ definition minimized/
+
+trait Issue413 {
+//    ^^^^^^^^ definition minimized/Issue413# trait Issue413
+  val b: Int
+//    ^ definition minimized/Issue413#b. val b: Int
+//       ^^^ reference scala/Int#
+}
+
+class Issue413Subclass extends Issue413 {
+//    ^^^^^^^^^^^^^^^^ definition minimized/Issue413Subclass# class Issue413Subclass
+//                      definition minimized/Issue413Subclass#`<init>`(). def this()
+//                             ^^^^^^^^ reference minimized/Issue413#
+//                                       reference java/lang/Object#`<init>`().
+  override val b = 10
+//             ^ definition minimized/Issue413Subclass#b. val b: Int
+}

--- a/tests/snapshots/src/main/generated/minimized/Issue414.scala
+++ b/tests/snapshots/src/main/generated/minimized/Issue414.scala
@@ -1,0 +1,30 @@
+package minimized
+//      ^^^^^^^^^ definition minimized/
+
+object Issue414 {
+//     ^^^^^^^^ definition minimized/Issue414. object Issue414
+  trait A {
+//      ^ definition minimized/Issue414.A# trait A
+    def b(): Unit
+//      ^ definition minimized/Issue414.A#b(). def b(): Unit
+//           ^^^^ reference scala/Unit#
+  }
+  val a: A =
+//    ^ definition minimized/Issue414.a. val a: A
+//       ^ reference minimized/Issue414.A#
+    new A {
+//       definition local0 final class $anon
+//      ^ reference minimized/Issue414.A#
+//         reference java/lang/Object#`<init>`().
+      override def b(): Unit = {
+//                 ^ definition local1 def b(): Unit
+//                      ^^^^ reference scala/Unit#
+        print("Hello")
+//      ^^^^^ reference scala/Predef.print().
+      }
+    }
+  println(a.b())
+//^^^^^^^ reference scala/Predef.println(+1).
+//        ^ reference minimized/Issue414.a.
+//          ^ reference minimized/Issue414.A#b().
+}

--- a/tests/snapshots/src/main/generated/minimized/ReflectiveCall.scala
+++ b/tests/snapshots/src/main/generated/minimized/ReflectiveCall.scala
@@ -1,0 +1,23 @@
+package minimized
+//      ^^^^^^^^^ definition minimized/
+
+import scala.language.reflectiveCalls
+//     ^^^^^ reference scala/
+//           ^^^^^^^^ reference scala/language.
+//                    ^^^^^^^^^^^^^^^ reference scala/language.reflectiveCalls.
+
+class ReflectiveCall {
+//    ^^^^^^^^^^^^^^ definition minimized/ReflectiveCall# class ReflectiveCall
+//                    definition minimized/ReflectiveCall#`<init>`(). def this()
+  // Reproduction for https://github.com/scalameta/scalameta/issues/2788
+  val a =
+//    ^ definition minimized/ReflectiveCall#a. val a: { val b: Int }
+    new {
+//       definition local0 final class $anon
+      val b = 1
+//        ^ definition local1 val b: Int
+    }
+  println(a.b)
+//^^^^^^^ reference scala/Predef.println(+1).
+//        ^ reference minimized/ReflectiveCall#a.
+}


### PR DESCRIPTION
Previously, scip-java only linked references for method symbols. This
commit changes the behavior to additionally include fields so that "find
references" for fields shows usages of all implementations of the field
(abstract super field and concrete implementations).

### Test plan

See newly added snapshot test that reproduces the issue. However, the snapshot test does not render the new "reference" relationship between the sub-field and super-field (I manually verified the relationship is correct by running `scip snapshot` locally).

https://sourcegraph.com/github.com/sourcegraph/sbt-sourcegraph@9ad1fc3cd0cd111552f99db1d0d869ecdf82d26d/-/blob/example/i413.scala?L12:25#tab=references

![CleanShot 2022-07-19 at 13 05 15](https://user-images.githubusercontent.com/1408093/179760196-976db3dc-a7c2-48c6-a1d6-5cdc4e448644.png)

We should consider updating the snapshot format to mirror the new `scip` cli tool


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
