### PR TITLE
Downgrade runtime proto dependency to 3.17.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ import scala.util.control.NoStackTrace
 
 lazy val V =
   new {
-    val protobuf = "3.21.4"
+    val protobuf = "3.15.6"
+    val protoc =
+      "3.17.3" // the oldest protoc version with Apple M1 support, see https://github.com/scalapb/ScalaPB/issues/1024#issuecomment-860126568
     val coursier = "2.0.8"
     val bsp = "2.0.0-M13"
     val moped = "0.1.10"
@@ -38,7 +40,7 @@ inThisBuild(
     organization := "com.sourcegraph",
     homepage := Some(url("https://github.com/sourcegraph/scip-java")),
     dynverSeparator := "-",
-    PB.protocVersion := V.protobuf,
+    PB.protocVersion := V.protoc,
     licenses :=
       List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers :=


### PR DESCRIPTION
Should fix #486 
### Test plan

See the CI go green.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
