### PR TITLE
Update coursier binary URL for Docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          cache: 'sbt'
+          distribution: "temurin"
+          cache: "sbt"
           java-version: ${{ matrix.java }}
       - run: sbt test
   bazel:
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
-          cache: 'sbt'
-      - run: sbt checkAll
+          cache: "sbt"
+      - run: sbt checkAll cli/docker

--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val cli = project
           "curl",
           "-fLo",
           "/usr/local/bin/coursier",
-          "https://git.io/coursier-cli"
+          "https://github.com/coursier/launchers/raw/master/coursier"
         )
         run("chmod", "+x", "/usr/local/bin/coursier")
 


### PR DESCRIPTION
The old URL pointed at an old Coursier binary that was unable to resolve
`--jvm 17`. I verified locally that the new binary works as expected.

### Test plan

See the CI go green with the new Docker step.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
