### PR TITLE
bump mill-scip version and improve mill testing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val V =
     def testcontainers = "0.39.3"
     def requests = "0.6.5"
     def minimalMillVersion = "0.10.0"
-    def millScipVersion = "0.2.2"
+    def millScipVersion = "0.2.3"
   }
 
 inThisBuild(

--- a/tests/buildTools/src/test/scala/tests/MillBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MillBuildToolSuite.scala
@@ -27,15 +27,47 @@ class MillBuildToolSuite extends BaseBuildToolSuite {
     List("./mill", "--version")
   }
 
-  List("0.10.0").foreach { version =>
+  def scalaLibrary(scalaVersion: String) =
+    if (scalaVersion.startsWith("3"))
+      List(
+        "maven:org.scala-lang:scala-library:2.13.8",
+        "maven:org.scala-lang:scala3-library_3:3.1.3"
+      ).mkString("\n")
+    else if (scalaVersion.startsWith("2.13"))
+      "maven:org.scala-lang:scala-library:2.13.8"
+    else if (scalaVersion.startsWith("2.12"))
+      "maven:org.scala-lang:scala-library:2.12.16"
+    else
+      "idn fail, we don't cover this scala version"
+
+  def scalaBinaryVersion(scalaVersion: String) =
+    if (scalaVersion.startsWith("3"))
+      "3"
+    else if (scalaVersion.startsWith("2.13"))
+      "2.13"
+    else if (scalaVersion.startsWith("2.12"))
+      "2.12"
+    else
+      "idn fail, we don't cover this scala version"
+
+  val supportedMillVersions = List("0.10.0")
+  val supportedScalaVersion = List("2.12.16", "2.13.8", "3.1.3")
+
+  val testGroupings =
+    for {
+      millVersion <- supportedMillVersions
+      scalaVersion <- supportedScalaVersion
+    } yield (millVersion, scalaVersion)
+
+  testGroupings.foreach { case (millVersion, scalaVersion) =>
     checkBuild(
-      s"minimal",
+      s"minimal-${millVersion}-${scalaVersion}",
       s"""|/.mill-version
-          |${version}
+          |${millVersion}
           |/build.sc
           |import mill._, scalalib._
           |object minimal extends ScalaModule {
-          |  def scalaVersion = "2.13.8"
+          |  def scalaVersion = "${scalaVersion}"
           |  object test extends Tests with TestModule.Munit {
           |    def ivyDeps = Agg(ivy"org.scalameta::munit:1.0.0-M6")
           | }
@@ -53,13 +85,13 @@ class MillBuildToolSuite extends BaseBuildToolSuite {
           |""".stripMargin,
       expectedSemanticdbFiles = 2,
       expectedPackages =
-        """|maven:junit:junit:4.13.2
-           |maven:org.hamcrest:hamcrest-core:1.3
-           |maven:org.scala-lang:scala-library:2.13.8
-           |maven:org.scala-sbt:test-interface:1.0
-           |maven:org.scalameta:junit-interface:1.0.0-M6
-           |maven:org.scalameta:munit_2.13:1.0.0-M6
-           |""".stripMargin,
+        s"""|maven:junit:junit:4.13.2
+            |maven:org.hamcrest:hamcrest-core:1.3
+            |${scalaLibrary(scalaVersion)}
+            |maven:org.scala-sbt:test-interface:1.0
+            |maven:org.scalameta:junit-interface:1.0.0-M6
+            |maven:org.scalameta:munit_${scalaBinaryVersion(scalaVersion)}:1.0.0-M6
+            |""".stripMargin,
       initCommand = setupMill(),
       targetRoot = Some("out/io/kipp/mill/scip/Scip/generate.dest")
     )

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -101,7 +101,7 @@ const Features = (props) => {
     {
       title: "Multiple build tools",
       content:
-        "The build tools Gradle, Maven and sbt are supported. We plan to add support for more build tools in the future.",
+        "The build tools Gradle, Maven, Mill, and sbt are supported. We plan to add support for more build tools in the future.",
       image:
         "https://user-images.githubusercontent.com/1408093/137899144-cfc6fc1b-a7c0-4fd7-ac4b-be516e459123.png",
       imageAlign: "right",


### PR DESCRIPTION

This pr improves the Mill testing by ensuring we are testing against all the
versions of Scala that mill-scip supports and it also bumps mill-scip to 0.2.3.

### Test plan

Ensure that the old and the new tests all pass.
