### PR TITLE
fix: ensure the scala codebase can be indexed

### DIFF
--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SignatureFormatter.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SignatureFormatter.java
@@ -23,6 +23,8 @@ public class SignatureFormatter {
 
   private static final Type NOTHING_SYMBOL = typeRef("scala/Nothing#");
   private static final String FUNCTION_SYMBOL_PREFIX = "scala/Function";
+  // Special case scala/Function object to not confluce with Function1 for example
+  private static final String FUNCTION_OBJECT = "scala/Function.";
   private static final String TUPLE_SYMBOL_PREFIX = "scala/Tuple";
   private static final String ARRAY_SYMBOL = "scala/Array#";
   private static final String ENUM_SYMBOL = "java/lang/Enum#";
@@ -557,7 +559,9 @@ public class SignatureFormatter {
           b.append(formatType(typeRef.getTypeArguments(0)));
           b.append("[]");
         }
-      } else if (isScala && typeRef.getSymbol().startsWith(FUNCTION_SYMBOL_PREFIX)) {
+      } else if (isScala
+          && typeRef.getSymbol().startsWith(FUNCTION_SYMBOL_PREFIX)
+          && !typeRef.getSymbol().startsWith(FUNCTION_OBJECT)) {
         int n = typeRef.getTypeArgumentsCount() - 1;
         if (n == 0) {
           // Special-case for Function1[A, B]: don't wrap `A`  in parenthesis like this `(A) => B`

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SignatureFormatter.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SignatureFormatter.java
@@ -23,7 +23,7 @@ public class SignatureFormatter {
 
   private static final Type NOTHING_SYMBOL = typeRef("scala/Nothing#");
   private static final String FUNCTION_SYMBOL_PREFIX = "scala/Function";
-  // Special case scala/Function object to not confluce with Function1 for example
+  // Special case scala/Function object to not conflict with Function1 for example
   private static final String FUNCTION_OBJECT = "scala/Function.";
   private static final String TUPLE_SYMBOL_PREFIX = "scala/Tuple";
   private static final String ARRAY_SYMBOL = "scala/Array#";
@@ -561,6 +561,7 @@ public class SignatureFormatter {
         }
       } else if (isScala
           && typeRef.getSymbol().startsWith(FUNCTION_SYMBOL_PREFIX)
+          && typeRef.getTypeArgumentsCount() > 0
           && !typeRef.getSymbol().startsWith(FUNCTION_OBJECT)) {
         int n = typeRef.getTypeArgumentsCount() - 1;
         if (n == 0) {


### PR DESCRIPTION
This took me an embarrassingly long time to catch what was going on ha.
But in the `SignatureFormatter` we special case things like `Function1`
to ensure we don't print `(A) => B` and instead `A => B`. We do this by
looking for symbols that start with `scala/Function`. However, the Scala
codebase has a `scala/Function.` object that causes this logic to trip
up. This change introduces another check to ensure that when we are in
Scala and see a symbol starting with `scala/Function` that it's not
`scala/Funtion.`.

This should get indexing working on the Scala codebase again.

Closes #475

### Test plan

I didn't really see any signature formatting tests, but here is s a gif showing that `Function.scala` is now is able to be indexed whereas before this would fail. 

![2022-08-20 16 33 07](https://user-images.githubusercontent.com/13974112/185751665-24920674-e0bf-4351-86d0-a74ce64e03ca.gif)

