### PR TITLE
chore(build): skip source generation in import for Jmh

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,6 +398,7 @@ lazy val bench = project
   .in(file("tests/benchmarks"))
   .settings(
     moduleName := "scip-java-bench",
+    Jmh / bspEnabled := false,
     (run / fork) := true,
     (publish / skip) := true
   )


### PR DESCRIPTION
This change turns `bspEnabled := false` for `Jmh` because it involves
source generation meaning that when you do a build import it will also
do the source generation which we don't want on import.

NOTE: That if there is another release of sbt-jmh ever this is done by
default not, but not yet released: https://github.com/sbt/sbt-jmh/pull/207.

### Test plan

Tests should just stay green.
