### PR TITLE
allow overriding JVM_VERSION in docker container

### DIFF
--- a/bin/scip-java-docker-script.sh
+++ b/bin/scip-java-docker-script.sh
@@ -3,7 +3,7 @@
 # version. It assumes that `coursier` is available on the `$PATH` and that the
 # `scip-java` binary is already installed at `/app/scip-java/bin/scip-java`.
 set -eu
-JVM_VERSION="8"
+JVM_VERSION="${JVM_VERSION:-8}"
 FILE="$PWD/lsif-java.json"
 if test -f "$FILE"; then
 	FROM_CONFIG=$(jq -r '.jvm' "$FILE")


### PR DESCRIPTION
Allows overriding of `JVM_VERSION` variable that defaults to `'8'` when using the docker image

### Test plan

Built the image using `sbt cli/docker` and ran auto-indexing locally using the command `JVM_VERSION=16 scip-java index`
