### PR TITLE
fix dependency indexing snapshot tests

### DIFF
--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexDependencyCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexDependencyCommand.scala
@@ -22,7 +22,7 @@ final case class IndexDependencyCommand(
       Paths.get("maven"),
     index: IndexCommand = IndexCommand(),
     @Hidden
-    snapshotCommand: SnapshotLsifCommand = SnapshotLsifCommand(),
+    snapshotCommand: SnapshotCommand = SnapshotCommand(),
     dependency: String = "",
     provided: List[String] = Nil,
     snapshot: Boolean = false


### PR DESCRIPTION
Main has been broken due to https://github.com/sourcegraph/scip-java/commit/14a92d8c3fc1e722bf24e923f3477856c58f0f48 changing the dependency indexing output to SCIP, but the snapshot tests expecting LSIF:
```
tests.LibrarySnapshotSuite:
==> X tests.LibrarySnapshotSuite.initializationError  0.004s java.util.NoSuchElementException: head of empty array
    at scala.collection.ArrayOps$.head$extension(ArrayOps.scala:222)
    at tests.LibrarySnapshotGenerator$Gen.checkLibrary(LibrarySnapshotGenerator.scala:66)
    at tests.LibrarySnapshotGenerator.run(LibrarySnapshotGenerator.scala:42)
    at tests.SnapshotSuite.<init>(SnapshotSuite.scala:10)
    at tests.LibrarySnapshotSuite.<init>(SnapshotSuite.scala:14)
```

Fixes the snapshot test to expect SCIP instead

### Test plan

Fixes a unit test, non-critical stuff
