### PR TITLE
fix: typo in args

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
@@ -55,7 +55,7 @@ public class SemanticdbJavacOptions {
         }
       } else if (arg.startsWith("-sourceroot:")) {
         result.sourceroot = Paths.get(arg.substring("-sourceroot:".length())).normalize();
-      } else if (arg.equals("-build-tool:sbt") || args.equals("-build-tool:mill")) {
+      } else if (arg.equals("-build-tool:sbt") || arg.equals("-build-tool:mill")) {
         result.uriScheme = UriScheme.ZINC;
       } else if (arg.equals("-build-tool:bazel")) {
         result.uriScheme = UriScheme.BAZEL;


### PR DESCRIPTION
Soooo, this was my mistake. I was curious why this wasn't working as expected and it's because we're checking `args` here instead of `arg`. Yay type safety.

### Test plan

Everything should test the same as before.
