### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/mdoc.yml
+++ b/.github/workflows/mdoc.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v3

--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -8,7 +8,7 @@ jobs:
   check-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: { repository: 'sourcegraph/sourcegraph' }
       - uses: actions/setup-go@v2
         with: { go-version: '1.18' }

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v3

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v3

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Upload SCIP"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'


### PR DESCRIPTION
Update to actions/checkout@v3 to avoid deprecation warning

### Test plan
Created as part of batch change: [_Created by Sourcegraph batch change `sourcegraph-operator-dax/Upgrade_actions_checkout_v2-v3`._](https://sourcegraph.sourcegraph.com/users/sourcegraph-operator-dax/batch-changes/Upgrade_actions_checkout_v2-v3)