### PR TITLE
feat: add support for the mill wrapper

### DIFF
--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MillBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/MillBuildTool.scala
@@ -1,9 +1,11 @@
 package com.sourcegraph.scip_java.buildtools
 
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 
 import scala.jdk.CollectionConverters._
+import scala.util.Properties
 
 import com.sourcegraph.scip_java.BuildInfo
 import com.sourcegraph.scip_java.commands.IndexCommand
@@ -38,14 +40,25 @@ class MillBuildTool(index: IndexCommand) extends BuildTool("mill", index) {
   private val rawOutput = index.output.toString
 
   private def unconditionallyGenerateScip(): Int = {
+    val millWrapper: Path = index
+      .workingDirectory
+      .resolve(
+        if (Properties.isWin)
+          "millw.bat"
+        else
+          "millw"
+      )
     val localMill =
       Files.isRegularFile(millFile) && Files.isExecutable(millFile)
-    val command =
-      if (localMill) {
+    val command: String =
+      if (Files.isRegularFile(millWrapper) && Files.isExecutable(millWrapper))
+        millWrapper.toString
+      else if (localMill) {
         "./mill"
       } else {
         "mill"
       }
+
     val millProcess = index.process(
       List(
         command,


### PR DESCRIPTION
This PR adds support for [mill wrapper](https://github.com/lefou/millw) based on the work to support wrapper for gradle. 

Ref: https://github.com/sourcegraph/scip-java/issues/533

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

I published scip-java locally - `sbt scip-java/publishLocal`, 
and then I invoked indexing in [my project](https://github.com/ghostbuster91/sttp-openapi-generator) via coursier - 
`cs launch com.sourcegraph:scip-java_2.13:0.8.13-1-e2b668bb-SNAPSHOT -- index --build-tool=mill`
Indexing completed successfully:

```
...
1/1] io.kipp.mill.scip.Scip.generate | [38/38] Finished creating your scip index
info: /home/kghost/workspace/sttp-openapi-generator/index.scip
```

In general it can be tested by running `scip-java index` in a scala project that uses mill together with mill wrapper. 

I did not write any automated tests as I didn't find anything like that for gradle wrapper. Let me know if I should add some automated tests. 