### PR TITLE
docs: fix SCIP link on getting started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,8 +3,8 @@ id: getting-started
 title: Getting started
 ---
 
-By following the instructions on this page, you should be able to generate an
-[SCIP](https://microsoft.github.io/language-server-protocol/specifications/scip/0.5.0/specification/)
+By following the instructions on this page, you should be able to generate a
+[SCIP](https://github.com/sourcegraph/scip)
 index of your Java codebase using Gradle or Maven. See
 [Supported build tools](#supported-build-tools) for an overview of other build
 tools that we're planning to support in the future.


### PR DESCRIPTION
When LSIF was renamed to SCIP a link to Microsoft's site was changed and it does not exist.
Changed the URL to point to our SCIP repo but not sure if we want to point to somewhere else.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
