### PR TITLE
Don't set java home per-configuration

### DIFF
--- a/project/JavaToolchainPlugin.scala
+++ b/project/JavaToolchainPlugin.scala
@@ -39,10 +39,6 @@ object JavaToolchainPlugin extends AutoPlugin {
     (doc / javacOptions) --= List("-target", "1.8"),
     (doc / javacOptions) --= bootclasspathSettings(javaToolchainVersion.value),
     (doc / javacOptions) --= List("-g"),
-    javaHome :=
-      Some(
-        getJavaHome(javaToolchainVersion.value, javaToolchainJvmIndex.value)
-      ),
     javacOptions ++= bootclasspathSettings(javaToolchainVersion.value),
     javaOptions ++= bootclasspathSettings(javaToolchainVersion.value)
   )
@@ -52,7 +48,11 @@ object JavaToolchainPlugin extends AutoPlugin {
       List(
         fork := true,
         javaToolchainVersion := "11",
-        javaToolchainJvmIndex := None
+        javaToolchainJvmIndex := None,
+        javaHome :=
+          Some(
+            getJavaHome(javaToolchainVersion.value, javaToolchainJvmIndex.value)
+          )
       )
 
   /**


### PR DESCRIPTION
I've been seeing lots of issues with `plugin/compile` not working - even on a clean machine.
It'd work once, and then next invocation crashes:

```
[info] compiling 21 Java sources to /Users/antonsviridov/projects/sourcegraph/scip-java/semanticdb-javac/target/classes ...
[warn] Unexpected javac output: Unrecognized option: --add-exports
[warn] Error: Could not create the Java Virtual Machine.
[warn] Error: A fatal exception has occurred. Program will exit..
[warn] javac exited with exit code 1
[debug] Rolling back changes to class files.
[debug] Removing generated classes:
[debug] Restoring class files:
[debug] Removing the temporary directory used for backing up class files: /Users/antonsviridov/projects/sourcegraph/scip-java/semanticdb-javac/target/classes.bak
[error] (plugin / Compile / compileIncremental) javac returned non-zero exit code
[error] Total time: 0 s, completed 19 Apr 2023, 10:06:41

sbt:root> plugin/Compile/javaHome
[info] Some(/Users/antonsviridov/Library/Caches/Coursier/arc/https/cdn.azul.com/zulu/bin/zulu8.68.0.21-ca-jdk8.0.362-macosx_aarch64.tar.gz/zulu8.68.0.21-ca-jdk8.0.362-macosx_aarch64)
```

If one takes a look at the debug output, it's clear that for some reason `javacOptions` have changed between runs: 
![image](https://user-images.githubusercontent.com/1052965/233039559-617a184a-450b-4b05-9159-9b4c31d1832a.png)

Randomly thrashing about I ended up removing the `javaHome` from per-configuration settings, to the global one.

Immediately I was successful in running `plugin/compile` multiple times without issue, along with rerunning tests without having to constantly clear the cache.

I cannot explain it, nor am I sure that this is _the_ fix, but it's a pretty strong signal on my machine that this change fixes one of the issues I was having.


### Test plan

CI shouldn't be affected by this change, manual testing confirms _some_ improvements.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
