### PR TITLE
Disable incremental compilation on managed java projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -311,7 +311,7 @@ lazy val minimizedSettings = List[Def.Setting[_]](
   (run / fork) := true,
   (Compile / unmanagedSourceDirectories) += minimizedSourceDirectory,
   libraryDependencies ++= List("org.projectlombok" % "lombok" % "1.18.22"),
-  (Compile / javacOptions) ++=
+  javacOptions ++=
     List[String](
       s"-Arandomtimestamp=${System.nanoTime()}",
       List(
@@ -327,13 +327,13 @@ lazy val minimizedSettings = List[Def.Setting[_]](
 
 lazy val minimized = project
   .in(file("tests/minimized/.j11"))
-  .settings(minimizedSettings)
+  .settings(minimizedSettings, javaOnlySettings)
   .dependsOn(agent, plugin)
   .disablePlugins(JavaFormatterPlugin)
 
 lazy val minimized8 = project
   .in(file("tests/minimized/.j8"))
-  .settings(minimizedSettings, javaToolchainVersion := "8")
+  .settings(minimizedSettings, javaToolchainVersion := "8", javaOnlySettings)
   .dependsOn(agent, plugin)
   .disablePlugins(JavaFormatterPlugin)
 
@@ -354,6 +354,7 @@ def javacModuleOptions =
 lazy val minimized17 = project
   .in(file("tests/minimized/.j17"))
   .settings(
+    javaOnlySettings,
     minimizedSettings,
     javaToolchainVersion := "17",
     javacOptions ++= javacModuleOptions
@@ -452,7 +453,7 @@ lazy val docs = project
 lazy val javaOnlySettings = List[Def.Setting[_]](
   autoScalaLibrary := false,
   incOptions ~= { old =>
-    old.withEnabled(false)
+    old.withEnabled(false).withApiDebug(true)
   },
   crossPaths := false
 )

--- a/project/JavaToolchainPlugin.scala
+++ b/project/JavaToolchainPlugin.scala
@@ -26,7 +26,7 @@ object JavaToolchainPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  lazy val configSettings = List(
+  override lazy val projectSettings: Seq[Def.Setting[_]] = List(
     javacOptions ++=
       List(
         "-target",
@@ -40,20 +40,13 @@ object JavaToolchainPlugin extends AutoPlugin {
     (doc / javacOptions) --= bootclasspathSettings(javaToolchainVersion.value),
     (doc / javacOptions) --= List("-g"),
     javacOptions ++= bootclasspathSettings(javaToolchainVersion.value),
-    javaOptions ++= bootclasspathSettings(javaToolchainVersion.value)
+    javaOptions ++= bootclasspathSettings(javaToolchainVersion.value),
+    fork := true,
+    javaToolchainVersion := "11",
+    javaToolchainJvmIndex := None,
+    javaHome :=
+      Some(getJavaHome(javaToolchainVersion.value, javaToolchainJvmIndex.value))
   )
-
-  override lazy val projectSettings: Seq[Def.Setting[_]] =
-    List(Compile, Test).flatMap(c => inConfig(c)(configSettings)) ++
-      List(
-        fork := true,
-        javaToolchainVersion := "11",
-        javaToolchainJvmIndex := None,
-        javaHome :=
-          Some(
-            getJavaHome(javaToolchainVersion.value, javaToolchainJvmIndex.value)
-          )
-      )
 
   /**
    * For Java 8, we need to manually add the Java compiler to the boot


### PR DESCRIPTION
1. Further simplify javac settings (no dependency scope)
2. Configure minimized projects as java only

Namely, disable incremental compilation, as it seems to wreak havoc

This is still whack-a-mole level of rigour, but at this point it seems to be more resilient to clean-compile-test loop.

### Test plan

- [x] Ensure CI is still green
- [x] Manually test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
