### PR TITLE
Publish CLI locally and use that version in the sbt-sourcegraph run

### DIFF
--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Install src
         run: yarn global add @sourcegraph/src
 
-      - name: sbt sourcegraphUpload
-        run: sbt sourcegraphUpload
+      - name: Publish CLI locally
+        run: sbt publishLocal dumpScipJavaVersion
 
+      - name: Upload sourcegraph data
+        run: sbt -Dscip-java-version=$(cat VERSION) sourcegraphUpload
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -1,10 +1,10 @@
 name: Sourcegraph
 on:
   push:
-    branches:
-      - main
-
+    branches: ["main"]
+    tags: ["v*"]
   pull_request:
+    branches: ["*"]
 
 jobs:
   scip:
@@ -18,13 +18,24 @@ jobs:
           java-version: 8
           cache: 'sbt'
 
-      - name: Install src
-        run: yarn global add @sourcegraph/src
-
       - name: Publish CLI locally
         run: sbt publishLocal dumpScipJavaVersion
 
+      - name: Produce SCIP data of scip-java repository
+        run: sbt -Dscip-java-version=$(cat VERSION) sourcegraphCompile
+
+      - name: Upload index.scip
+        uses: actions/upload-artifact@master
+        with:
+          path: index.scip
+          if-no-files-found: error
+
+      - name: Install src
+        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')
+        run: yarn global add @sourcegraph/src
+
       - name: Upload sourcegraph data
+        if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')
         run: sbt -Dscip-java-version=$(cat VERSION) sourcegraphUpload
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -12,6 +12,9 @@ jobs:
     name: "Upload SCIP"
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/sourcegraph.yml
+++ b/.github/workflows/sourcegraph.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Upload index.scip
         uses: actions/upload-artifact@master
         with:
-          path: index.scip
+          path: target/sbt-sourcegraph/index.scip
+          name: index.scip
           if-no-files-found: error
 
       - name: Install src

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ bazel-scip-java
 bazel-out
 bazel-testlogs
 bazel-lsif-java
+
+VERSION

--- a/build.sbt
+++ b/build.sbt
@@ -436,6 +436,8 @@ lazy val bench = project
 lazy val docs = project
   .in(file("scip-java-docs"))
   .settings(
+    publishLocal / skip := true,
+    publish / skip := true,
     moduleName := "scip-java-docs",
     mdocOut :=
       (ThisBuild / baseDirectory).value / "website" / "target" / "docs",
@@ -525,3 +527,12 @@ lazy val fatjarPackageSettings = List[Def.Setting[_]](
     ).transform(node).head
   }
 )
+
+lazy val dumpScipJavaVersion = taskKey[Unit](
+  "Dump the version of scip-java tool to a VERSION file"
+)
+dumpScipJavaVersion := {
+  val versionValue = (cli / version).value
+
+  IO.write((ThisBuild / baseDirectory).value / "VERSION", versionValue)
+}


### PR DESCRIPTION
1. Dogfood the auto-indexing on this codebase by publishing it locally and using that version to index scip-java itself
2. Do (1) on all PRs to avoid regressions


### Test plan

- After merge to main, verify that the sourcegraph workflow runs successfully and uploads new data
- On this PR, verify that index.scip file is uploaded to the job results

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
