### PR TITLE
Fix a regression where the SCIP index contained invalid symbols

### DIFF
--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/ScipPrinters.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/ScipPrinters.scala
@@ -149,6 +149,10 @@ object ScipPrinters {
         caretCharacter * width
 
     val symbol = syntheticDefinition.fold(occ.getSymbol)(_.getSymbol)
+
+    // Fail the tests if the index contains symbols that don't parse as valid SCIP symbols.
+    val _ = ScipSymbol.parseOrThrowExceptionIfInvalid(symbol)
+
     out
       .append(comment)
       .append(indent)

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/ScipSymbol.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/ScipSymbol.scala
@@ -1,0 +1,55 @@
+package com.sourcegraph.scip_java
+
+import com.sourcegraph.scip_semanticdb.SymbolDescriptor
+import com.sourcegraph.semanticdb_javac.SemanticdbSymbols
+
+sealed abstract class ScipSymbol {}
+final case class LocalScipSymbol(identifier: String) extends ScipSymbol
+final case class GlobalScipSymbol(
+    scheme: String,
+    packageManager: String,
+    packageName: String,
+    packageVersion: String,
+    descriptors: List[SymbolDescriptor]
+) extends ScipSymbol
+
+object ScipSymbol {
+
+  def parseOrThrowExceptionIfInvalid(scipSymbol: String): ScipSymbol = {
+    if (scipSymbol.startsWith("local ")) {
+      LocalScipSymbol(scipSymbol.stripPrefix("local "))
+    } else {
+      scipSymbol.split(" ", 5) match {
+        case Array(
+              scheme,
+              packageManager,
+              packageName,
+              packageVersion,
+              descriptor
+            ) =>
+          GlobalScipSymbol(
+            scheme,
+            packageManager,
+            packageName,
+            packageVersion,
+            parseDescriptors(descriptor)
+          )
+        case _ =>
+          throw new IllegalArgumentException(
+            s"Invalid scip symbol: $scipSymbol"
+          )
+      }
+    }
+  }
+
+  private def parseDescriptors(
+      semanticdbSymbol: String
+  ): List[SymbolDescriptor] = {
+    val descriptor = SymbolDescriptor.parseFromSymbol(semanticdbSymbol)
+    if (descriptor.owner == SemanticdbSymbols.ROOT_PACKAGE)
+      Nil
+    else
+      descriptor :: parseDescriptors(descriptor.owner)
+  }
+
+}

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
@@ -137,9 +137,11 @@ public class ScipSemanticdb {
         ArrayList<String> inverseReferences = references.map.get(info.getSymbol());
         if (inverseReferences != null) {
           for (String inverseReference : inverseReferences) {
+            Package inverseReferencePkg =
+                packages.packageForSymbol(inverseReference).orElse(Package.EMPTY);
             scipInfo.addRelationships(
                 Scip.Relationship.newBuilder()
-                    .setSymbol(inverseReference)
+                    .setSymbol(typedSymbol(inverseReference, inverseReferencePkg))
                     .setIsImplementation(true)
                     .setIsReference(true));
           }

--- a/tests/snapshots/src/main/generated/ByteParser.scala
+++ b/tests/snapshots/src/main/generated/ByteParser.scala
@@ -107,9 +107,9 @@ abstract class ByteParser[J] extends upickle.core.BufferingByteParser{
   protected[this] def close(): Unit
 //                    ^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/ByteParser#close().
 //                          documentation ```scala\ndef close(): Unit\n```
-//                          relationship is_reference is_implementation ujson/ByteArrayParser#close().
-//                          relationship is_reference is_implementation ujson/ByteBufferParser#close().
-//                          relationship is_reference is_implementation ujson/InputStreamParser#close().
+//                          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/ByteArrayParser#close().
+//                          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/ByteBufferParser#close().
+//                          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/InputStreamParser#close().
 //                             ^^^^ reference semanticdb maven maven/org.scala-lang/scala-library 2.13.10 scala/Unit#
 
   /**

--- a/tests/snapshots/src/main/generated/CharParser.scala
+++ b/tests/snapshots/src/main/generated/CharParser.scala
@@ -107,8 +107,8 @@ abstract class CharParser[J] extends upickle.core.BufferingCharParser{
   protected[this] def close(): Unit
 //                    ^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/CharParser#close().
 //                          documentation ```scala\ndef close(): Unit\n```
-//                          relationship is_reference is_implementation ujson/CharSequenceParser#close().
-//                          relationship is_reference is_implementation ujson/StringParser#close().
+//                          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/CharSequenceParser#close().
+//                          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/StringParser#close().
 //                             ^^^^ reference semanticdb maven maven/org.scala-lang/scala-library 2.13.10 scala/Unit#
 
   /**

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/AsyncEpoxyDiffer.java
@@ -60,7 +60,7 @@ class AsyncEpoxyDiffer {
     void onResult(@NonNull DiffResult result);
 //       ^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/AsyncEpoxyDiffer#ResultCallback#onResult().
 //                documentation ```java\npublic abstract void onResult(DiffResult result)\n```
-//                relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onResult().
+//                relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onResult().
 //                 ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/DiffResult#
 //                                    ^^^^^^ definition local 0

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyAdapter.java
@@ -145,7 +145,7 @@ public abstract class BaseEpoxyAdapter
 //               ^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#onExceptionSwallowed().
 //                                    documentation ```java\nprotected void onExceptionSwallowed(RuntimeException exception)\n```
 //                                    documentation  This is called when recoverable exceptions happen at runtime. They can be ignored and Epoxy\n will recover, but you can override this to be aware of when they happen.\n
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onExceptionSwallowed().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onExceptionSwallowed().
 //                                    ^^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/RuntimeException#
 //                                                     ^^^^^^^^^ definition local 0
 //                                                               documentation ```java\nRuntimeException exception\n```
@@ -157,7 +157,7 @@ public abstract class BaseEpoxyAdapter
   public int getItemCount() {
 //           ^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#getItemCount().
 //                        documentation ```java\n@Override\npublic int getItemCount()\n```
-//                        relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#getItemCount().
+//                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#getItemCount().
     return getCurrentModels().size();
 //         ^^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                            ^^^^ reference semanticdb maven jdk 11 java/util/List#size().
@@ -170,8 +170,8 @@ public abstract class BaseEpoxyAdapter
 //                                       ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#getCurrentModels().
 //                                                        documentation ```java\nabstract List<? extends EpoxyModel<?>> getCurrentModels()\n```
 //                                                        documentation Return the models currently being used by the adapter to populate the recyclerview. 
-//                                                        relationship is_reference is_implementation com/airbnb/epoxy/EpoxyAdapter#getCurrentModels().
-//                                                        relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#getCurrentModels().
+//                                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#getCurrentModels().
+//                                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#getCurrentModels().
 
   public boolean isEmpty() {
 //               ^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#isEmpty().
@@ -345,7 +345,7 @@ public abstract class BaseEpoxyAdapter
   boolean diffPayloadsEnabled() {
 //        ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#diffPayloadsEnabled().
 //                            documentation ```java\nboolean diffPayloadsEnabled()\n```
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#diffPayloadsEnabled().
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#diffPayloadsEnabled().
     return false;
   }
 
@@ -381,7 +381,7 @@ public abstract class BaseEpoxyAdapter
   void onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position,
 //     ^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#onModelBound(+1).
 //                  documentation ```java\nvoid onModelBound(EpoxyViewHolder holder, EpoxyModel<?> model, int position, EpoxyModel<?> previouslyBoundModel)\n```
-//                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onModelBound().
+//                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onModelBound().
 //                  ^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyViewHolder#
 //                                  ^^^^^^ definition local 18
 //                                         documentation ```java\nEpoxyViewHolder holder\n```
@@ -431,8 +431,8 @@ public abstract class BaseEpoxyAdapter
 //                           ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#getBoundViewHolders().
 //                                               documentation ```java\nprotected BoundViewHolders getBoundViewHolders()\n```
 //                                               documentation  Returns an object that manages the view holders currently bound to the RecyclerView. This\n object is mainly used by the base Epoxy adapter to save view states, but you may find it useful\n to help access views or models currently shown in the RecyclerView.\n
-//                                               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#getBoundViewHolders().
-//                                               relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#getBoundViewHolders().
+//                                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#getBoundViewHolders().
+//                                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#getBoundViewHolders().
     return boundViewHolders;
 //         ^^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#boundViewHolders.
   }
@@ -441,7 +441,7 @@ public abstract class BaseEpoxyAdapter
 //^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //              ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#getModelForPosition().
 //                                  documentation ```java\nEpoxyModel<?> getModelForPosition(int position)\n```
-//                                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyAdapter#getModelForPosition().
+//                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#getModelForPosition().
 //                                      ^^^^^^^^ definition local 25
 //                                               documentation ```java\nint position\n```
     return getCurrentModels().get(position);
@@ -489,7 +489,7 @@ public abstract class BaseEpoxyAdapter
   public void onDetachedFromRecyclerView(@NonNull RecyclerView recyclerView) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#onDetachedFromRecyclerView().
 //                                       documentation ```java\n@CallSuper\n@Override\npublic void onDetachedFromRecyclerView(unresolved_type recyclerView)\n```
-//                                       relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onDetachedFromRecyclerView().
+//                                       relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onDetachedFromRecyclerView().
 //                                        ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                                                ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                                             ^^^^^^^^^^^^ definition local 28
@@ -510,7 +510,7 @@ public abstract class BaseEpoxyAdapter
 //               ^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#onModelUnbound().
 //                              documentation ```java\nprotected void onModelUnbound(EpoxyViewHolder holder, EpoxyModel<?> model)\n```
 //                              documentation  Called immediately after a model is unbound from a view holder. Subclasses can override this if\n they want alerts on when a model is unbound.\n
-//                              relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onModelUnbound().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onModelUnbound().
 //                              ^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyViewHolder#
 //                                              ^^^^^^ definition local 29
 //                                                     documentation ```java\nEpoxyViewHolder holder\n```
@@ -547,7 +547,7 @@ public abstract class BaseEpoxyAdapter
   public void onViewAttachedToWindow(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#onViewAttachedToWindow().
 //                                   documentation ```java\n@CallSuper\n@Override\npublic void onViewAttachedToWindow(EpoxyViewHolder holder)\n```
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onViewAttachedToWindow().
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onViewAttachedToWindow().
 //                                   ^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyViewHolder#
 //                                                   ^^^^^^ definition local 32
 //                                                          documentation ```java\nEpoxyViewHolder holder\n```
@@ -568,7 +568,7 @@ public abstract class BaseEpoxyAdapter
   public void onViewDetachedFromWindow(EpoxyViewHolder holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#onViewDetachedFromWindow().
 //                                     documentation ```java\n@CallSuper\n@Override\npublic void onViewDetachedFromWindow(EpoxyViewHolder holder)\n```
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#onViewDetachedFromWindow().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#onViewDetachedFromWindow().
 //                                     ^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyViewHolder#
 //                                                     ^^^^^^ definition local 33
 //                                                            documentation ```java\nEpoxyViewHolder holder\n```
@@ -662,8 +662,8 @@ public abstract class BaseEpoxyAdapter
 //              ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#getModelPosition().
 //                               documentation ```java\nprotected int getModelPosition(EpoxyModel<?> model)\n```
 //                               documentation  Finds the position of the given model in the list. Doesn't use indexOf to avoid unnecessary\n equals() calls since we're looking for the same object instance.\n\n @return The position of the given model in the current models list, or -1 if the model can't be\n found.\n
-//                               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#getModelPosition().
-//                               relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#getModelPosition().
+//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#getModelPosition().
+//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#getModelPosition().
 //                               ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                             ^^^^^ definition local 37
 //                                                   documentation ```java\nEpoxyModel<?> model\n```
@@ -753,7 +753,7 @@ public abstract class BaseEpoxyAdapter
 //            ^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#setupStickyHeaderView().
 //                                  documentation ```java\n@Override\npublic void setupStickyHeaderView(unresolved_type stickyHeader)\n```
 //                                  documentation  Optional callback to setup the sticky view,\n by default it doesn't do anything.\n <p>\n The sub-classes should override the function if they are\n using sticky header feature.\n
-//                                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#setupStickyHeaderView().
+//                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#setupStickyHeaderView().
 //                                   ^^^^^^^ reference semanticdb maven maven/org.jetbrains/annotations 13.0 org/jetbrains/annotations/NotNull#
 //                                           ^^^^ reference semanticdb maven . . _root_/
 //                                                ^^^^^^^^^^^^ definition local 41
@@ -774,7 +774,7 @@ public abstract class BaseEpoxyAdapter
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#teardownStickyHeaderView().
 //                                     documentation ```java\n@Override\npublic void teardownStickyHeaderView(unresolved_type stickyHeader)\n```
 //                                     documentation  Optional callback to perform tear down operation on the\n sticky view, by default it doesn't do anything.\n <p>\n The sub-classes should override the function if they are\n using sticky header feature.\n
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#teardownStickyHeaderView().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#teardownStickyHeaderView().
 //                                      ^^^^^^^ reference semanticdb maven maven/org.jetbrains/annotations 13.0 org/jetbrains/annotations/NotNull#
 //                                              ^^^^ reference semanticdb maven . . _root_/
 //                                                   ^^^^^^^^^^^^ definition local 42
@@ -795,7 +795,7 @@ public abstract class BaseEpoxyAdapter
 //               ^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyAdapter#isStickyHeader().
 //                              documentation ```java\n@Override\npublic boolean isStickyHeader(int position)\n```
 //                              documentation  Called to check if the item at the position is a sticky item,\n by default returns false.\n <p>\n The sub-classes should override the function if they are\n using sticky header feature.\n
-//                              relationship is_reference is_implementation com/airbnb/epoxy/EpoxyControllerAdapter#isStickyHeader().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyControllerAdapter#isStickyHeader().
 //                                  ^^^^^^^^ definition local 43
 //                                           documentation ```java\nint position\n```
     return false;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
@@ -8,8 +8,8 @@ import android.view.View;
 interface BaseEpoxyTouchCallback<T extends EpoxyModel> {
 //        ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                               documentation ```java\ninterface BaseEpoxyTouchCallback<T extends EpoxyModel>\n```
-//                               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyDragCallback#
-//                               relationship is_reference is_implementation com/airbnb/epoxy/EpoxySwipeCallback#
+//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#
+//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#
 //                               ^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#[T]
 //                                 documentation ```java\nT extends EpoxyModel\n```
 //                                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
@@ -28,8 +28,8 @@ interface BaseEpoxyTouchCallback<T extends EpoxyModel> {
 //    ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#getMovementFlagsForModel().
 //                             documentation ```java\npublic abstract int getMovementFlagsForModel(T model, int adapterPosition)\n```
 //                             documentation  Should return a composite flag which defines the enabled move directions in each state\n (idle, swiping, dragging) for the given model.\n <p>\n Return 0 to disable movement for the model.\n\n @param model           The model being targeted for movement.\n @param adapterPosition The current adapter position of the targeted model\n @see androidx.recyclerview.widget.ItemTouchHelper.Callback#getMovementFlags\n
-//                             relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#getMovementFlagsForModel().
-//                             relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#getMovementFlagsForModel().
+//                             relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#getMovementFlagsForModel().
+//                             relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#getMovementFlagsForModel().
 //                             ^ reference semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#[T]
 //                               ^^^^^ definition local 0
 //                                     documentation ```java\nT model\n```
@@ -50,10 +50,10 @@ interface BaseEpoxyTouchCallback<T extends EpoxyModel> {
 //     ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#clearView().
 //               documentation ```java\npublic abstract void clearView(T model, unresolved_type itemView)\n```
 //               documentation  Called when the user interaction with a view is over and the view has\n completed its animation. This is a good place to clear all changes on the view that were done\n in other previous touch callbacks (such as on touch start, change, release, etc).\n <p>\n This is the last callback in the lifecycle of a touch event.\n\n @param model    The model whose view is being cleared.\n @param itemView The view being cleared.\n
-//               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
-//               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
-//               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#clearView().
-//               relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#clearView().
+//               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
+//               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
+//               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#clearView().
+//               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#clearView().
 //               ^ reference semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#[T]
 //                 ^^^^^ definition local 2
 //                       documentation ```java\nT model\n```

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelper.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/ControllerHelper.java
@@ -22,7 +22,7 @@ public abstract class ControllerHelper<T extends EpoxyController> {
   public abstract void resetAutoModels();
 //                     ^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/ControllerHelper#resetAutoModels().
 //                                     documentation ```java\npublic abstract void resetAutoModels()\n```
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/NoOpControllerHelper#resetAutoModels().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/NoOpControllerHelper#resetAutoModels().
 
   protected void validateModelHashCodesHaveNotChanged(T controller) {
 //               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/ControllerHelper#validateModelHashCodesHaveNotChanged().

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyAdapter.java
@@ -88,7 +88,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#enableDiffing().
 //                             documentation ```java\nprotected void enableDiffing()\n```
 //                             documentation  Enables support for automatically notifying model changes via {@link #notifyModelsChanged()}.\n If used, this should be called in the constructor, before any models are changed.\n\n @see #notifyModelsChanged()\n
-//                             relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#enableDiffing().
+//                             relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#enableDiffing().
     if (diffHelper != null) {
 //      ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#diffHelper.
       throw new IllegalStateException("Diffing was already enabled");
@@ -153,7 +153,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#notifyModelsChanged().
 //                                   documentation ```java\nprotected void notifyModelsChanged()\n```
 //                                   documentation  Intelligently notify item changes by comparing the current {@link #models} list against the\n previous so you don't have to micromanage notification calls yourself. This may be\n prohibitively slow for large model lists (in the hundreds), in which case consider doing\n notification calls yourself. If you use this, all your view models must implement {@link\n EpoxyModel#hashCode()} and {@link EpoxyModel#equals(Object)} to completely identify their\n state, so that changes to a model's content can be detected. Before using this you must enable\n it with {@link #enableDiffing()}, since keeping track of the model state adds extra computation\n time to all other data change notifications.\n\n @see #enableDiffing()\n
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#notifyModelsChanged().
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#notifyModelsChanged().
     if (diffHelper == null) {
 //      ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#diffHelper.
       throw new IllegalStateException("You must enable diffing before notifying models changed");
@@ -173,7 +173,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#notifyModelChanged().
 //                                  documentation ```java\nprotected void notifyModelChanged(EpoxyModel<?> model)\n```
 //                                  documentation  Notify that the given model has had its data changed. It should only be called if the model\n retained the same position.\n
-//                                  relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#notifyModelChanged().
+//                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#notifyModelChanged().
 //                                  ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                ^^^^^ definition local 2
 //                                                      documentation ```java\nEpoxyModel<?> model\n```
@@ -249,7 +249,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#addModels().
 //                         documentation ```java\nprotected void addModels(EpoxyModel<?>[] modelsToAdd)\n```
 //                         documentation  Adds the models to the end of the {@link #models} list and notifies that the items were\n inserted.\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#addModels().
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#addModels().
 //                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                          ^^^^^^^^^^^ definition local 8
 //                                                      documentation ```java\nEpoxyModel<?>[] modelsToAdd\n```
@@ -295,7 +295,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#addModels(+1).
 //                         documentation ```java\nprotected void addModels(Collection<? extends EpoxyModel<?>> modelsToAdd)\n```
 //                         documentation  Adds the models to the end of the {@link #models} list and notifies that the items were\n inserted.\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#addModels(+1).
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#addModels(+1).
 //                         ^^^^^^^^^^ reference semanticdb maven jdk 11 java/util/Collection#
 //                                              ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                             ^^^^^^^^^^^ definition local 11
@@ -330,7 +330,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#insertModelBefore().
 //                                 documentation ```java\nprotected void insertModelBefore(EpoxyModel<?> modelToInsert, EpoxyModel<?> modelToInsertBefore)\n```
 //                                 documentation  Inserts the given model before the other in the {@link #models} list, and notifies that the\n item was inserted.\n
-//                                 relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#insertModelBefore().
+//                                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#insertModelBefore().
 //                                 ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                               ^^^^^^^^^^^^^ definition local 13
 //                                                             documentation ```java\nEpoxyModel<?> modelToInsert\n```
@@ -372,7 +372,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#insertModelAfter().
 //                                documentation ```java\nprotected void insertModelAfter(EpoxyModel<?> modelToInsert, EpoxyModel<?> modelToInsertAfter)\n```
 //                                documentation  Inserts the given model after the other in the {@link #models} list, and notifies that the item\n was inserted.\n
-//                                relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#insertModelAfter().
+//                                relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#insertModelAfter().
 //                                ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                              ^^^^^^^^^^^^^ definition local 16
 //                                                            documentation ```java\nEpoxyModel<?> modelToInsert\n```
@@ -418,7 +418,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#removeModel().
 //                           documentation ```java\nprotected void removeModel(EpoxyModel<?> model)\n```
 //                           documentation  If the given model exists it is removed and an item removal is notified. Otherwise this does\n nothing.\n
-//                           relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#removeModel().
+//                           relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#removeModel().
 //                           ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                         ^^^^^ definition local 20
 //                                               documentation ```java\nEpoxyModel<?> model\n```
@@ -451,7 +451,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#removeAllModels().
 //                               documentation ```java\nprotected void removeAllModels()\n```
 //                               documentation  Removes all models\n
-//                               relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#removeAllModels().
+//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#removeAllModels().
     int numModelsRemoved = models.size();
 //      ^^^^^^^^^^^^^^^^ definition local 22
 //                       documentation ```java\nint numModelsRemoved\n```
@@ -480,7 +480,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#removeAllAfterModel().
 //                                   documentation ```java\nprotected void removeAllAfterModel(EpoxyModel<?> model)\n```
 //                                   documentation  Removes all models after the given model, which must have already been added. An example use\n case is you want to keep a header but clear everything else, like in the case of refreshing\n data.\n
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#removeAllAfterModel().
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#removeAllAfterModel().
 //                                   ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                 ^^^^^ definition local 23
 //                                                       documentation ```java\nEpoxyModel<?> model\n```
@@ -529,7 +529,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#showModel().
 //                         documentation ```java\nprotected void showModel(EpoxyModel<?> model, boolean show)\n```
 //                         documentation  Sets the visibility of the given model, and notifies that the item changed if the new\n visibility is different from the previous.\n\n @param model The model to show. It should already be added to the {@link #models} list.\n @param show  True to show the model, false to hide it.\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#showModel().
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#showModel().
 //                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                       ^^^^^ definition local 27
 //                                             documentation ```java\nEpoxyModel<?> model\n```
@@ -560,7 +560,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#showModel(+1).
 //                         documentation ```java\nprotected void showModel(EpoxyModel<?> model)\n```
 //                         documentation  Shows the given model, and notifies that the item changed if the item wasn't already shown.\n\n @param model The model to show. It should already be added to the {@link #models} list.\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#showModel(+1).
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#showModel(+1).
 //                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                       ^^^^^ definition local 29
 //                                             documentation ```java\nEpoxyModel<?> model\n```
@@ -578,7 +578,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#showModels().
 //                          documentation ```java\nprotected void showModels(EpoxyModel<?>[] models)\n```
 //                          documentation  Shows the given models, and notifies that each item changed if the item wasn't already shown.\n\n @param models The models to show. They should already be added to the {@link #models} list.\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#showModels().
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#showModels().
 //                          ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                           ^^^^^^ definition local 30
 //                                                  documentation ```java\nEpoxyModel<?>[] models\n```
@@ -600,7 +600,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#showModels(+1).
 //                          documentation ```java\nprotected void showModels(boolean show, EpoxyModel<?>[] models)\n```
 //                          documentation  Sets the visibility of the given models, and notifies that the items changed if the new\n visibility is different from the previous.\n\n @param models The models to show. They should already be added to the {@link #models} list.\n @param show   True to show the models, false to hide them.\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+1).
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+1).
 //                                  ^^^^ definition local 31
 //                                       documentation ```java\nboolean show\n```
 //                                        ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
@@ -623,7 +623,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#showModels(+2).
 //                          documentation ```java\nprotected void showModels(Iterable<EpoxyModel<?>> models)\n```
 //                          documentation  Shows the given models, and notifies that each item changed if the item wasn't already shown.\n\n @param models The models to show. They should already be added to the {@link #models} list.\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+2).
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+2).
 //                          ^^^^^^^^ reference semanticdb maven jdk 11 java/lang/Iterable#
 //                                   ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                  ^^^^^^ definition local 33
@@ -644,7 +644,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#showModels(+3).
 //                          documentation ```java\nprotected void showModels(Iterable<EpoxyModel<?>> models, boolean show)\n```
 //                          documentation  Sets the visibility of the given models, and notifies that the items changed if the new\n visibility is different from the previous.\n\n @param models The models to show. They should already be added to the {@link #models} list.\n @param show   True to show the models, false to hide them.\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+3).
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#showModels(+3).
 //                          ^^^^^^^^ reference semanticdb maven jdk 11 java/lang/Iterable#
 //                                   ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                  ^^^^^^ definition local 34
@@ -672,7 +672,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#hideModel().
 //                         documentation ```java\nprotected void hideModel(EpoxyModel<?> model)\n```
 //                         documentation  Hides the given model, and notifies that the item changed if the item wasn't already hidden.\n\n @param model The model to hide. This should already be added to the {@link #models} list.\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#hideModel().
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#hideModel().
 //                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                       ^^^^^ definition local 37
 //                                             documentation ```java\nEpoxyModel<?> model\n```
@@ -690,7 +690,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#hideModels().
 //                          documentation ```java\nprotected void hideModels(Iterable<EpoxyModel<?>> models)\n```
 //                          documentation  Hides the given models, and notifies that each item changed if the item wasn't already hidden.\n\n @param models The models to hide. They should already be added to the {@link #models} list.\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#hideModels().
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#hideModels().
 //                          ^^^^^^^^ reference semanticdb maven jdk 11 java/lang/Iterable#
 //                                   ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                  ^^^^^^ definition local 38
@@ -709,7 +709,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#hideModels(+1).
 //                          documentation ```java\nprotected void hideModels(EpoxyModel<?>[] models)\n```
 //                          documentation  Hides the given models, and notifies that each item changed if the item wasn't already hidden.\n\n @param models The models to hide. They should already be added to the {@link #models} list.\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#hideModels(+1).
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#hideModels(+1).
 //                          ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                           ^^^^^^ definition local 39
 //                                                  documentation ```java\nEpoxyModel<?>[] models\n```
@@ -729,7 +729,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //               ^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#hideAllAfterModel().
 //                                 documentation ```java\nprotected void hideAllAfterModel(EpoxyModel<?> model)\n```
 //                                 documentation  Hides all models currently located after the given model in the {@link #models} list.\n\n @param model The model after which to hide. It must exist in the {@link #models} list.\n
-//                                 relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#hideAllAfterModel().
+//                                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#hideAllAfterModel().
 //                                 ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                               ^^^^^ definition local 40
 //                                                     documentation ```java\nEpoxyModel<?> model\n```
@@ -752,7 +752,7 @@ public abstract class EpoxyAdapter extends BaseEpoxyAdapter {
 //                              ^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyAdapter#getAllModelsAfter().
 //                                                documentation ```java\nprotected List<EpoxyModel<?>> getAllModelsAfter(EpoxyModel<?> model)\n```
 //                                                documentation  Returns a sub list of all items in {@link #models} that occur after the given model. This list\n is backed by the original models list, any changes to the returned list will be reflected in\n the original {@link #models} list.\n\n @param model Must exist in {@link #models}.\n
-//                                                relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyAdapter#getAllModelsAfter().
+//                                                relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyAdapter#getAllModelsAfter().
 //                                                ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#
 //                                                              ^^^^^ definition local 41
 //                                                                    documentation ```java\nEpoxyModel<?> model\n```

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -344,11 +344,11 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //            ^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyController#requestModelBuild().
 //                              documentation ```java\npublic void requestModelBuild()\n```
 //                              documentation  Call this to request a model update. The controller will schedule a call to {@link\n #buildModels()} so that models can be rebuilt for the current data. Once a build is requested\n all subsequent requests are ignored until the model build runs. Therefore, the calling code\n need not worry about calling this multiple times in a row.\n <p>\n The exception is that the first time this is called on a new instance of {@link\n EpoxyController} it is run synchronously. This allows state to be restored and the initial view\n to be draw quicker.\n <p>\n If you would like to be alerted when models have finished building use\n {@link #addModelBuildListener(OnModelBuildFinishedListener)}\n
-//                              relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyController#requestModelBuild().
-//                              relationship is_reference is_implementation com/airbnb/epoxy/Typed2EpoxyController#requestModelBuild().
-//                              relationship is_reference is_implementation com/airbnb/epoxy/Typed3EpoxyController#requestModelBuild().
-//                              relationship is_reference is_implementation com/airbnb/epoxy/Typed4EpoxyController#requestModelBuild().
-//                              relationship is_reference is_implementation com/airbnb/epoxy/TypedEpoxyController#requestModelBuild().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyController#requestModelBuild().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed2EpoxyController#requestModelBuild().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed3EpoxyController#requestModelBuild().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed4EpoxyController#requestModelBuild().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/TypedEpoxyController#requestModelBuild().
     if (isBuildingModels()) {
 //      ^^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyController#isBuildingModels().
       throw new IllegalEpoxyUsage("Cannot call `requestModelBuild` from inside `buildModels`");
@@ -455,10 +455,10 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyController#requestDelayedModelBuild().
 //                                                  documentation ```java\npublic void requestDelayedModelBuild(int delayMs)\n```
 //                                                  documentation  Call this to request a delayed model update. The controller will schedule a call to {@link\n #buildModels()} so that models can be rebuilt for the current data.\n <p>\n Using this to delay a model update may be helpful in cases where user input is causing many\n rapid changes in the models, such as typing. In that case, the view is already updated on\n screen and constantly rebuilding models is potentially slow and unnecessary. The downside to\n delaying the model build too long is that models will not be in sync with the data or view, and\n scrolling the view offscreen and back onscreen will cause the model to bind old data.\n <p>\n If a previous request is still pending it will be removed in favor of this new delay\n <p>\n Any call to {@link #requestModelBuild()} will override a delayed request.\n <p>\n In most cases you should use {@link #requestModelBuild()} instead of this.\n\n @param delayMs The time in milliseconds to delay the model build by. Should be greater than or\n                equal to 0. A value of 0 is equivalent to calling {@link #requestModelBuild()}\n
-//                                                  relationship is_reference is_implementation com/airbnb/epoxy/Typed2EpoxyController#requestDelayedModelBuild().
-//                                                  relationship is_reference is_implementation com/airbnb/epoxy/Typed3EpoxyController#requestDelayedModelBuild().
-//                                                  relationship is_reference is_implementation com/airbnb/epoxy/Typed4EpoxyController#requestDelayedModelBuild().
-//                                                  relationship is_reference is_implementation com/airbnb/epoxy/TypedEpoxyController#requestDelayedModelBuild().
+//                                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed2EpoxyController#requestDelayedModelBuild().
+//                                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed3EpoxyController#requestDelayedModelBuild().
+//                                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed4EpoxyController#requestDelayedModelBuild().
+//                                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/TypedEpoxyController#requestDelayedModelBuild().
 //                                                      ^^^^^^^ definition local 4
 //                                                              documentation ```java\nint delayMs\n```
     if (isBuildingModels()) {
@@ -657,11 +657,11 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //                        ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyController#buildModels().
 //                                    documentation ```java\nprotected abstract void buildModels()\n```
 //                                    documentation  Subclasses should implement this to describe what models should be shown for the current state.\n Implementations should call either {@link #add(EpoxyModel)}, {@link\n EpoxyModel#addTo(EpoxyController)}, or {@link EpoxyModel#addIf(boolean, EpoxyController)} with\n the models that should be shown, in the order that is desired.\n <p>\n Once a model is added to the controller it should be treated as immutable and never modified\n again. This is necessary for adapter updates to be accurate. If "validateEpoxyModelUsage" is\n enabled then runtime validations will be done to make sure models are not changed.\n <p>\n You CANNOT call this method directly. Instead, call {@link #requestModelBuild()} to have the\n controller schedule an update.\n
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyController#buildModels().
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/Typed2EpoxyController#buildModels().
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/Typed3EpoxyController#buildModels().
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/Typed4EpoxyController#buildModels().
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/TypedEpoxyController#buildModels().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyController#buildModels().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed2EpoxyController#buildModels().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed3EpoxyController#buildModels().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed4EpoxyController#buildModels().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/TypedEpoxyController#buildModels().
 
   int getFirstIndexOfModelInBuildingList(EpoxyModel<?> model) {
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyController#getFirstIndexOfModelInBuildingList().
@@ -1411,10 +1411,10 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 //            ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyController#moveModel().
 //                      documentation ```java\npublic void moveModel(int fromPosition, int toPosition)\n```
 //                      documentation  An optimized way to move a model from one position to another without rebuilding all models.\n This is intended to be used with {@link androidx.recyclerview.widget.ItemTouchHelper} to\n allow for efficient item dragging and rearranging. It cannot be\n <p>\n If you call this you MUST also update the data backing your models as necessary.\n <p>\n This will immediately change the model's position and notify the change to the RecyclerView.\n However, a delayed request to rebuild models will be scheduled for the future to guarantee that\n models are in sync with data.\n\n @param fromPosition Previous position of the item.\n @param toPosition   New position of the item.\n
-//                      relationship is_reference is_implementation com/airbnb/epoxy/Typed2EpoxyController#moveModel().
-//                      relationship is_reference is_implementation com/airbnb/epoxy/Typed3EpoxyController#moveModel().
-//                      relationship is_reference is_implementation com/airbnb/epoxy/Typed4EpoxyController#moveModel().
-//                      relationship is_reference is_implementation com/airbnb/epoxy/TypedEpoxyController#moveModel().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed2EpoxyController#moveModel().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed3EpoxyController#moveModel().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/Typed4EpoxyController#moveModel().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/TypedEpoxyController#moveModel().
 //                          ^^^^^^^^^^^^ definition local 50
 //                                       documentation ```java\nint fromPosition\n```
 //                                            ^^^^^^^^^^ definition local 51

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDragCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDragCallback.java
@@ -34,8 +34,8 @@ public interface EpoxyDragCallback<T extends EpoxyModel> extends BaseEpoxyTouchC
 //     ^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#onDragStarted().
 //                   documentation ```java\npublic abstract void onDragStarted(T model, unresolved_type itemView, int adapterPosition)\n```
 //                   documentation  Called when the view switches from an idle state to a dragged state, as the user begins a drag\n interaction with it. You can use this callback to modify the view to indicate it is being\n dragged.\n <p>\n This is the first callback in the lifecycle of a drag event.\n\n @param model           The model representing the view that is being dragged\n @param itemView        The view that is being dragged\n @param adapterPosition The adapter position of the model\n
-//                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onDragStarted().
-//                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onDragStarted().
+//                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onDragStarted().
+//                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onDragStarted().
 //                   ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#[T]
 //                     ^^^^^ definition local 0
 //                           documentation ```java\nT model\n```
@@ -63,8 +63,8 @@ public interface EpoxyDragCallback<T extends EpoxyModel> extends BaseEpoxyTouchC
 //     ^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#onModelMoved().
 //                  documentation ```java\npublic abstract void onModelMoved(int fromPosition, int toPosition, T modelBeingMoved, unresolved_type itemView)\n```
 //                  documentation  Called after {@link #onDragStarted(EpoxyModel, View, int)} when the dragged view is dropped to\n a new position. The EpoxyController will be updated automatically for you to reposition the\n models and notify the RecyclerView of the change.\n <p>\n You MUST use this callback to modify your data backing the models to reflect the change.\n <p>\n The next callback in the drag lifecycle will be {@link #onDragStarted(EpoxyModel, View, int)}\n\n @param modelBeingMoved The model representing the view that was moved\n @param itemView        The view that was moved\n @param fromPosition    The adapter position that the model came from\n @param toPosition      The new adapter position of the model\n
-//                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onModelMoved().
-//                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onModelMoved().
+//                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onModelMoved().
+//                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onModelMoved().
 //                      ^^^^^^^^^^^^ definition local 3
 //                                   documentation ```java\nint fromPosition\n```
 //                                        ^^^^^^^^^^ definition local 4
@@ -94,8 +94,8 @@ public interface EpoxyDragCallback<T extends EpoxyModel> extends BaseEpoxyTouchC
 //     ^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#onDragReleased().
 //                    documentation ```java\npublic abstract void onDragReleased(T model, unresolved_type itemView)\n```
 //                    documentation  Called after {@link #onDragStarted(EpoxyModel, View, int)} when the view being dragged is\n released. If the view was dragged to a new, valid location then {@link #onModelMoved(int, int,\n EpoxyModel, View)} will be called before this and the view will settle to the new location.\n Otherwise the view will animate back to its original position.\n <p>\n You can use this callback to modify the view as it animates back into position.\n <p>\n {@link BaseEpoxyTouchCallback#clearView(EpoxyModel, View)} will be called after this, when the\n view has finished animating. Final cleanup of the view should be done there.\n\n @param model    The model representing the view that is being released\n @param itemView The view that was being dragged\n
-//                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onDragReleased().
-//                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onDragReleased().
+//                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onDragReleased().
+//                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#DragCallbacks#onDragReleased().
 //                    ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#[T]
 //                      ^^^^^ definition local 7
 //                            documentation ```java\nT model\n```

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModel.java
@@ -185,7 +185,7 @@ public abstract class EpoxyModel<T> {
 //              ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#getViewType().
 //                          documentation ```java\nprotected int getViewType()\n```
 //                          documentation  Get the view type to associate with this model in the recyclerview. For models that use a\n layout resource, the view type is simply the layout resource value by default.\n <p>\n If this returns 0 Epoxy will assign a unique view type for this model at run time.\n\n @see androidx.recyclerview.widget.RecyclerView.Adapter#getItemViewType(int)\n
-//                          relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithView#getViewType().
+//                          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithView#getViewType().
     return getLayout();
 //         ^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#getLayout().
   }
@@ -199,7 +199,7 @@ public abstract class EpoxyModel<T> {
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#buildView().
 //                         documentation ```java\nprotected unresolved_type buildView(unresolved_type parent)\n```
 //                         documentation  Create and return a new instance of a view for this model. By default a view is created by\n inflating the layout resource.\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithView#buildView().
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithView#buildView().
 //                          ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                                  ^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                            ^^^^^^ definition local 1
@@ -222,9 +222,9 @@ public abstract class EpoxyModel<T> {
 //            ^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#bind().
 //                 documentation ```java\npublic void bind(T view)\n```
 //                 documentation  Binds the current data to the given view. You should bind all fields including unset/empty\n fields to ensure proper recycling.\n
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#bind().
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#bind().
-//                 relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyModel#bind().
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#bind().
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#bind().
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyModel#bind().
 //                  ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                          ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                            ^^^^ definition local 2
@@ -244,8 +244,8 @@ public abstract class EpoxyModel<T> {
 //            ^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#bind(+1).
 //                 documentation ```java\npublic void bind(T view, List<Object> payloads)\n```
 //                 documentation  Similar to {@link #bind(Object)}, but provides a non null, non empty list of payloads\n describing what changed. This is the payloads list specified in the adapter's notifyItemChanged\n method. This is a useful optimization to allow you to only change part of a view instead of\n updating the whole thing, which may prevent unnecessary layout calls. If there are no payloads\n then {@link #bind(Object)} is called instead. This will only be used if the model is used with\n an {@link EpoxyAdapter}\n
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#bind(+1).
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#bind(+1).
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#bind(+1).
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#bind(+1).
 //                  ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                          ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                            ^^^^ definition local 3
@@ -295,8 +295,8 @@ public abstract class EpoxyModel<T> {
 //            ^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#bind(+2).
 //                 documentation ```java\npublic void bind(T view, EpoxyModel<?> previouslyBoundModel)\n```
 //                 documentation  Similar to {@link #bind(Object)}, but provides a non null model which was previously bound to\n this view. This will only be called if the model is used with an {@link EpoxyController}.\n\n @param previouslyBoundModel This is a model with the same id that was previously bound. You can\n                             compare this previous model with the current one to see exactly\n                             what changed.\n                             <p>\n                             This model and the previously bound model are guaranteed to have\n                             the same id, but will not necessarily be of the same type depending\n                             on your implementation of {@link EpoxyController#buildModels()}.\n                             With common usage patterns of Epoxy they should be the same type,\n                             and will only differ if you are using different model classes with\n                             the same id.\n                             <p>\n                             Comparing the newly bound model with the previous model allows you\n                             to be more intelligent when binding your view. This may help you\n                             optimize view binding, or make it easier to work with animations.\n                             <p>\n                             If the new model and the previous model have the same view type\n                             (given by {@link EpoxyModel#getViewType()}), and if you are using\n                             the default ReyclerView item animator, the same view will be\n                             reused. This means that you only need to update the view to reflect\n                             the data that changed. If you are using a custom item animator then\n                             the view will be the same if the animator returns true in\n                             canReuseUpdatedViewHolder.\n                             <p>\n                             This previously bound model is taken as a payload from the diffing\n                             process, and follows the same general conditions for all\n                             recyclerview change payloads.\n
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#bind(+2).
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#bind(+2).
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#bind(+2).
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#bind(+2).
 //                  ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                          ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                            ^^^^ definition local 5
@@ -324,9 +324,9 @@ public abstract class EpoxyModel<T> {
 //            ^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#unbind().
 //                   documentation ```java\npublic void unbind(T view)\n```
 //                   documentation  Called when the view bound to this model is recycled. Subclasses can override this if their\n view should release resources when it's recycled.\n <p>\n Note that {@link #bind(Object)} can be called multiple times without an unbind call in between\n if the view has remained on screen to be reused across item changes. This means that you should\n not rely on unbind to clear a view or model's state before bind is called again.\n\n @see EpoxyAdapter#onViewRecycled(EpoxyViewHolder)\n
-//                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#unbind().
-//                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#unbind().
-//                   relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyModel#unbind().
+//                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#unbind().
+//                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#unbind().
+//                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyModel#unbind().
 //                    ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                            ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                              ^^^^ definition local 7
@@ -342,7 +342,7 @@ public abstract class EpoxyModel<T> {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onVisibilityStateChanged().
 //                                     documentation ```java\npublic void onVisibilityStateChanged(int visibilityState, T view)\n```
 //                                     documentation  TODO link to the wiki\n\n @see OnVisibilityStateChanged annotation\n
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#onVisibilityStateChanged().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onVisibilityStateChanged().
 //                                      ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/VisibilityState#Visibility#
 //                                                     ^^^^^^^^^^^^^^^ definition local 8
 //                                                                     documentation ```java\n@Visibility\nint visibilityState\n```
@@ -361,7 +361,7 @@ public abstract class EpoxyModel<T> {
 //            ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onVisibilityChanged().
 //                                documentation ```java\npublic void onVisibilityChanged(float percentVisibleHeight, float percentVisibleWidth, int visibleHeight, int visibleWidth, T view)\n```
 //                                documentation  TODO link to the wiki\n\n @see OnVisibilityChanged annotation\n
-//                                relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#onVisibilityChanged().
+//                                relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onVisibilityChanged().
       @FloatRange(from = 0.0f, to = 100.0f) float percentVisibleHeight,
 //     ^^^^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/FloatRange#
 //                ^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/FloatRange#from().
@@ -629,10 +629,10 @@ public abstract class EpoxyModel<T> {
 //                       ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#getDefaultLayout().
 //                                        documentation ```java\n@LayoutRes\nprotected abstract int getDefaultLayout()\n```
 //                                        documentation  Return the default layout resource to be used when creating views for this model. The resource\n will be inflated to create a view for the model; additionally the layout int is used as the\n views type in the RecyclerView.\n <p>\n This can be left unimplemented if you use the {@link EpoxyModelClass} annotation to define a\n layout.\n <p>\n This default value can be overridden with {@link #layout(int)} at runtime to change the layout\n dynamically.\n
-//                                        relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#getDefaultLayout().
-//                                        relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithView#getDefaultLayout().
-//                                        relationship is_reference is_implementation com/airbnb/epoxy/HiddenEpoxyModel#getDefaultLayout().
-//                                        relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyModel#getDefaultLayout().
+//                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#getDefaultLayout().
+//                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithView#getDefaultLayout().
+//                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/HiddenEpoxyModel#getDefaultLayout().
+//                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyModel#getDefaultLayout().
 
   @NonNull
 // ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
@@ -641,7 +641,7 @@ public abstract class EpoxyModel<T> {
 //                  ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                     ^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#layout().
 //                            documentation ```java\n@NonNull\npublic EpoxyModel<T> layout(int layoutRes)\n```
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithView#layout().
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithView#layout().
 //                             ^^^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/LayoutRes#
 //                                           ^^^^^^^^^ definition local 30
 //                                                     documentation ```java\n@LayoutRes\nint layoutRes\n```
@@ -968,8 +968,8 @@ public abstract class EpoxyModel<T> {
   public boolean equals(Object o) {
 //               ^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#equals().
 //                      documentation ```java\n@Override\npublic boolean equals(Object o)\n```
-//                      relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#equals().
-//                      relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyModel#equals().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#equals().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyModel#equals().
 //                      relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/Object#equals().
 //                      ^^^^^^ reference semanticdb maven jdk 11 java/lang/Object#
 //                             ^ definition local 47
@@ -1014,8 +1014,8 @@ public abstract class EpoxyModel<T> {
   public int hashCode() {
 //           ^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#hashCode().
 //                    documentation ```java\n@Override\npublic int hashCode()\n```
-//                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#hashCode().
-//                    relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyModel#hashCode().
+//                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#hashCode().
+//                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyModel#hashCode().
 //                    relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/Object#hashCode().
     int result = (int) (id ^ (id >>> 32));
 //      ^^^^^^ definition local 49
@@ -1046,9 +1046,9 @@ public abstract class EpoxyModel<T> {
 //           ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#getSpanSize().
 //                       documentation ```java\npublic int getSpanSize(int totalSpanCount, int position, int itemCount)\n```
 //                       documentation  Subclasses can override this if they want their view to take up more than one span in a grid\n layout.\n\n @param totalSpanCount The number of spans in the grid\n @param position       The position of the model\n @param itemCount      The total number of items in the adapter\n
-//                       relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#getSpanSize().
-//                       relationship is_reference is_implementation com/airbnb/epoxy/HiddenEpoxyModel#getSpanSize().
-//                       relationship is_reference is_implementation com/airbnb/epoxy/SimpleEpoxyModel#getSpanSize().
+//                       relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#getSpanSize().
+//                       relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/HiddenEpoxyModel#getSpanSize().
+//                       relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/SimpleEpoxyModel#getSpanSize().
 //                           ^^^^^^^^^^^^^^ definition local 50
 //                                          documentation ```java\nint totalSpanCount\n```
 //                                               ^^^^^^^^ definition local 51
@@ -1194,7 +1194,7 @@ public abstract class EpoxyModel<T> {
 //               ^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#shouldSaveViewState().
 //                                   documentation ```java\npublic boolean shouldSaveViewState()\n```
 //                                   documentation  Whether the adapter should save the state of the view bound to this model.\n
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState(+1).
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#shouldSaveViewState(+1).
     return false;
   }
 
@@ -1211,7 +1211,7 @@ public abstract class EpoxyModel<T> {
 //               ^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onFailedToRecycleView().
 //                                     documentation ```java\npublic boolean onFailedToRecycleView(T view)\n```
 //                                     documentation  Called if the RecyclerView failed to recycle this model's view. You can take this opportunity\n to clear the animation(s) that affect the View's transient state and return <code>true</code>\n so that the View can be recycled. Keep in mind that the View in question is already removed\n from the RecyclerView.\n\n @return True if the View should be recycled, false otherwise\n @see EpoxyAdapter#onFailedToRecycleView(androidx.recyclerview.widget.RecyclerView.ViewHolder)\n
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#onFailedToRecycleView().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onFailedToRecycleView().
 //                                      ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                                              ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                                                ^^^^ definition local 61
@@ -1228,8 +1228,8 @@ public abstract class EpoxyModel<T> {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onViewAttachedToWindow().
 //                                   documentation ```java\npublic void onViewAttachedToWindow(T view)\n```
 //                                   documentation  Called when this model's view is attached to the window.\n\n @see EpoxyAdapter#onViewAttachedToWindow(androidx.recyclerview.widget.RecyclerView.ViewHolder)\n
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#onViewAttachedToWindow().
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#onViewAttachedToWindow().
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#onViewAttachedToWindow().
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onViewAttachedToWindow().
 //                                    ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                                            ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                                              ^^^^ definition local 62
@@ -1247,8 +1247,8 @@ public abstract class EpoxyModel<T> {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onViewDetachedFromWindow().
 //                                     documentation ```java\npublic void onViewDetachedFromWindow(T view)\n```
 //                                     documentation  Called when this model's view is detached from the the window.\n\n @see EpoxyAdapter#onViewDetachedFromWindow(androidx.recyclerview.widget.RecyclerView\n .ViewHolder)\n
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#onViewDetachedFromWindow().
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelWithHolder#onViewDetachedFromWindow().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#onViewDetachedFromWindow().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onViewDetachedFromWindow().
 //                                      ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                                              ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#[T]
 //                                                ^^^^ definition local 63

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyModelWithHolder.java
@@ -66,7 +66,7 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
 //                     ^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#createNewHolder().
 //                                     documentation ```java\nprotected abstract T createNewHolder(unresolved_type parent)\n```
 //                                     documentation This should return a new instance of your {@link com.airbnb.epoxy.EpoxyHolder} class. 
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#createNewHolder().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#createNewHolder().
 //                                      ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                                              ^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                                         ^^^^^^ definition local 1
@@ -77,8 +77,8 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void bind(@NonNull T holder) {
 //            ^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#bind().
 //                 documentation ```java\n@Override\npublic void bind(T holder)\n```
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#bind().
 //                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModel#bind().
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#bind().
 //                  ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                          ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 //                            ^^^^^^ definition local 2
@@ -94,8 +94,8 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void bind(@NonNull T holder, @NonNull List<Object> payloads) {
 //            ^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#bind(+1).
 //                 documentation ```java\n@Override\npublic void bind(T holder, List<Object> payloads)\n```
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#bind(+1).
 //                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModel#bind(+1).
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#bind(+1).
 //                  ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                          ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 //                            ^^^^^^ definition local 3
@@ -117,8 +117,8 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void bind(@NonNull T holder, @NonNull EpoxyModel<?> previouslyBoundModel) {
 //            ^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#bind(+2).
 //                 documentation ```java\n@Override\npublic void bind(T holder, EpoxyModel<?> previouslyBoundModel)\n```
-//                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#bind(+2).
 //                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModel#bind(+2).
+//                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#bind(+2).
 //                  ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                          ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 //                            ^^^^^^ definition local 5
@@ -139,8 +139,8 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void unbind(@NonNull T holder) {
 //            ^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#unbind().
 //                   documentation ```java\n@Override\npublic void unbind(T holder)\n```
-//                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#unbind().
 //                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModel#unbind().
+//                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#unbind().
 //                    ^^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/NonNull#
 //                            ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 //                              ^^^^^^ definition local 7
@@ -235,8 +235,8 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void onViewAttachedToWindow(T holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onViewAttachedToWindow().
 //                                   documentation ```java\n@Override\npublic void onViewAttachedToWindow(T holder)\n```
-//                                   relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#onViewAttachedToWindow().
 //                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onViewAttachedToWindow().
+//                                   relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#onViewAttachedToWindow().
 //                                   ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 //                                     ^^^^^^ definition local 16
 //                                            documentation ```java\nT holder\n```
@@ -251,8 +251,8 @@ public abstract class EpoxyModelWithHolder<T extends EpoxyHolder> extends EpoxyM
   public void onViewDetachedFromWindow(T holder) {
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#onViewDetachedFromWindow().
 //                                     documentation ```java\n@Override\npublic void onViewDetachedFromWindow(T holder)\n```
-//                                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelGroup#onViewDetachedFromWindow().
 //                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModel#onViewDetachedFromWindow().
+//                                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelGroup#onViewDetachedFromWindow().
 //                                     ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModelWithHolder#[T]
 //                                       ^^^^^^ definition local 17
 //                                              documentation ```java\nT holder\n```

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxySwipeCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxySwipeCallback.java
@@ -44,8 +44,8 @@ public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouch
 //     ^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#onSwipeStarted().
 //                    documentation ```java\npublic abstract void onSwipeStarted(T model, unresolved_type itemView, int adapterPosition)\n```
 //                    documentation  Called when the view switches from an idle state to a swiped state, as the user begins a swipe\n interaction with it. You can use this callback to modify the view to indicate it is being\n swiped.\n <p>\n This is the first callback made in the lifecycle of a swipe event.\n\n @param model           The model representing the view that is being swiped\n @param itemView        The view that is being swiped\n @param adapterPosition The adapter position of the model\n
-//                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeStarted().
-//                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeStarted().
+//                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeStarted().
+//                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeStarted().
 //                    ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#[T]
 //                      ^^^^^ definition local 0
 //                            documentation ```java\nT model\n```
@@ -73,8 +73,8 @@ public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouch
 //     ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#onSwipeProgressChanged().
 //                            documentation ```java\npublic abstract void onSwipeProgressChanged(T model, unresolved_type itemView, float swipeProgress, unresolved_type canvas)\n```
 //                            documentation  Once a view has begun swiping with {@link #onSwipeStarted(EpoxyModel, View, int)} it will\n receive this callback as the swipe distance changes. This can be called multiple times as the\n swipe interaction progresses.\n\n @param model         The model representing the view that is being swiped\n @param itemView      The view that is being swiped\n @param swipeProgress A float from -1 to 1 representing the percentage that the view has been\n                      swiped relative to its width. This will be positive if the view is being\n                      swiped to the right and negative if it is swiped to the left. For\n                      example,\n @param canvas        The canvas on which RecyclerView is drawing its children. You can draw to\n                      this to support custom swipe animations.\n
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeProgressChanged().
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeProgressChanged().
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeProgressChanged().
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeProgressChanged().
 //                            ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#[T]
 //                              ^^^^^ definition local 3
 //                                    documentation ```java\nT model\n```
@@ -101,8 +101,8 @@ public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouch
 //     ^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#onSwipeReleased().
 //                     documentation ```java\npublic abstract void onSwipeReleased(T model, unresolved_type itemView)\n```
 //                     documentation  Called when the user has released their touch on the view. If the displacement passed the swipe\n threshold then {@link #onSwipeCompleted(EpoxyModel, View, int, int)} will be called after this\n and the view will be animated off screen. Otherwise the view will animate back to its original\n position.\n\n @param model    The model representing the view that was being swiped\n @param itemView The view that was being swiped\n
-//                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeReleased().
-//                     relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeReleased().
+//                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeReleased().
+//                     relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeReleased().
 //                     ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#[T]
 //                       ^^^^^ definition local 7
 //                             documentation ```java\nT model\n```
@@ -131,8 +131,8 @@ public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouch
 //     ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#onSwipeCompleted().
 //                      documentation ```java\npublic abstract void onSwipeCompleted(T model, unresolved_type itemView, int position, int direction)\n```
 //                      documentation  Called after {@link #onSwipeReleased(EpoxyModel, View)} if the swipe surpassed the threshold to\n be considered a full swipe. The view will now be animated off screen.\n <p>\n You MUST use this callback to remove this item from your backing data and request a model\n update.\n <p>\n {@link #clearView(EpoxyModel, View)} will be called after this.\n\n @param model     The model representing the view that was being swiped\n @param itemView  The view that was being swiped\n @param position  The adapter position of the model\n @param direction The direction that the view was swiped. Can be any of {@link\n                  ItemTouchHelper#LEFT}, {@link ItemTouchHelper#RIGHT}, {@link\n                  ItemTouchHelper#UP}, {@link ItemTouchHelper#DOWN} depending on what swipe\n                  directions were enabled.\n
-//                      relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeCompleted().
-//                      relationship is_reference is_implementation com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeCompleted().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onSwipeCompleted().
+//                      relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelper#SwipeCallbacks#onSwipeCompleted().
 //                      ^ reference semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#[T]
 //                        ^^^^^ definition local 9
 //                              documentation ```java\nT model\n```

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyTouchHelperCallback.java
@@ -46,7 +46,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final int getMovementFlags(RecyclerView recyclerView, ViewHolder viewHolder) {
 //                 ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#getMovementFlags().
 //                                  documentation ```java\n@Override\npublic final int getMovementFlags(unresolved_type recyclerView, unresolved_type viewHolder)\n```
-//                                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#getMovementFlags().
+//                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#getMovementFlags().
 //                                  ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                               ^^^^^^^^^^^^ definition local 0
 //                                                            documentation ```java\nunresolved_type recyclerView\n```
@@ -67,7 +67,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                       ^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#getMovementFlags(+1).
 //                                        documentation ```java\nprotected abstract int getMovementFlags(unresolved_type recyclerView, EpoxyViewHolder viewHolder)\n```
 //                                        documentation  @see #getMovementFlags(RecyclerView, ViewHolder)\n
-//                                        relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#getMovementFlags().
+//                                        relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#getMovementFlags().
 //                                        ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                                     ^^^^^^^^^^^^ definition local 2
 //                                                                  documentation ```java\nunresolved_type recyclerView\n```
@@ -80,7 +80,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final boolean onMove(RecyclerView recyclerView, ViewHolder viewHolder, ViewHolder target) {
 //                     ^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#onMove().
 //                            documentation ```java\n@Override\npublic final boolean onMove(unresolved_type recyclerView, unresolved_type viewHolder, unresolved_type target)\n```
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onMove().
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onMove().
 //                            ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                         ^^^^^^^^^^^^ definition local 4
 //                                                      documentation ```java\nunresolved_type recyclerView\n```
@@ -106,7 +106,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                           ^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#onMove(+1).
 //                                  documentation ```java\nprotected abstract boolean onMove(unresolved_type recyclerView, EpoxyViewHolder viewHolder, EpoxyViewHolder target)\n```
 //                                  documentation  @see #onMove(RecyclerView, ViewHolder, ViewHolder)\n
-//                                  relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onMove().
+//                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onMove().
 //                                  ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                               ^^^^^^^^^^^^ definition local 7
 //                                                            documentation ```java\nunresolved_type recyclerView\n```
@@ -123,7 +123,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final void onSwiped(ViewHolder viewHolder, int direction) {
 //                  ^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#onSwiped().
 //                           documentation ```java\n@Override\npublic final void onSwiped(unresolved_type viewHolder, int direction)\n```
-//                           relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onSwiped().
+//                           relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onSwiped().
 //                           ^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                      ^^^^^^^^^^ definition local 10
 //                                                 documentation ```java\nunresolved_type viewHolder\n```
@@ -154,7 +154,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final boolean canDropOver(RecyclerView recyclerView, ViewHolder current,
 //                     ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#canDropOver().
 //                                 documentation ```java\n@Override\npublic final boolean canDropOver(unresolved_type recyclerView, unresolved_type current, unresolved_type target)\n```
-//                                 relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#canDropOver().
+//                                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#canDropOver().
 //                                 ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                              ^^^^^^^^^^^^ definition local 14
 //                                                           documentation ```java\nunresolved_type recyclerView\n```
@@ -181,7 +181,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //                  ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#canDropOver(+1).
 //                              documentation ```java\nprotected boolean canDropOver(unresolved_type recyclerView, EpoxyViewHolder current, EpoxyViewHolder target)\n```
 //                              documentation  @see #canDropOver(RecyclerView, ViewHolder, ViewHolder)\n
-//                              relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#canDropOver().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#canDropOver().
 //                              ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                           ^^^^^^^^^^^^ definition local 17
 //                                                        documentation ```java\nunresolved_type recyclerView\n```
@@ -328,7 +328,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final void onSelectedChanged(ViewHolder viewHolder, int actionState) {
 //                  ^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#onSelectedChanged().
 //                                    documentation ```java\n@Override\npublic final void onSelectedChanged(unresolved_type viewHolder, int actionState)\n```
-//                                    relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onSelectedChanged().
+//                                    relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onSelectedChanged().
 //                                    ^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                               ^^^^^^^^^^ definition local 32
 //                                                          documentation ```java\nunresolved_type viewHolder\n```
@@ -440,8 +440,8 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final void clearView(RecyclerView recyclerView, ViewHolder viewHolder) {
 //                  ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#clearView().
 //                            documentation ```java\n@Override\npublic final void clearView(unresolved_type recyclerView, unresolved_type viewHolder)\n```
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
-//                            relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
+//                            relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
 //                            ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                         ^^^^^^^^^^^^ definition local 50
 //                                                      documentation ```java\nunresolved_type recyclerView\n```
@@ -462,8 +462,8 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //               ^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#clearView(+1).
 //                         documentation ```java\nprotected void clearView(unresolved_type recyclerView, EpoxyViewHolder viewHolder)\n```
 //                         documentation  @see #clearView(RecyclerView, ViewHolder)\n
-//                         relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
-//                         relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#clearView().
+//                         relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#clearView(+1).
 //                         ^^^^^^^^^^^^ reference semanticdb maven . . _root_/
 //                                      ^^^^^^^^^^^^ definition local 52
 //                                                   documentation ```java\nunresolved_type recyclerView\n```
@@ -482,7 +482,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
   public final void onChildDraw(Canvas c, RecyclerView recyclerView, ViewHolder viewHolder,
 //                  ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#onChildDraw().
 //                              documentation ```java\n@Override\npublic final void onChildDraw(unresolved_type c, unresolved_type recyclerView, unresolved_type viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive)\n```
-//                              relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onChildDraw().
+//                              relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onChildDraw().
 //                              ^^^^^^ reference semanticdb maven . . _root_/
 //                                     ^ definition local 54
 //                                       documentation ```java\nunresolved_type c\n```
@@ -523,7 +523,7 @@ public abstract class EpoxyTouchHelperCallback extends ItemTouchHelper.Callback 
 //               ^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyTouchHelperCallback#onChildDraw(+1).
 //                           documentation ```java\nprotected void onChildDraw(unresolved_type c, unresolved_type recyclerView, EpoxyViewHolder viewHolder, float dX, float dY, int actionState, boolean isCurrentlyActive)\n```
 //                           documentation  @see #onChildDraw(Canvas, RecyclerView, ViewHolder, float, float, int, boolean)\n
-//                           relationship is_reference is_implementation com/airbnb/epoxy/EpoxyModelTouchCallback#onChildDraw().
+//                           relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyModelTouchCallback#onChildDraw().
 //                           ^^^^^^ reference semanticdb maven . . _root_/
 //                                  ^ definition local 61
 //                                    documentation ```java\nunresolved_type c\n```

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/Timer.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/Timer.java
@@ -6,14 +6,14 @@ interface Timer {
   void start(String sectionName);
 //     ^^^^^ definition semanticdb maven . . com/airbnb/epoxy/Timer#start().
 //           documentation ```java\npublic abstract void start(String sectionName)\n```
-//           relationship is_reference is_implementation com/airbnb/epoxy/DebugTimer#start().
-//           relationship is_reference is_implementation com/airbnb/epoxy/NoOpTimer#start().
+//           relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/DebugTimer#start().
+//           relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/NoOpTimer#start().
 //           ^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
 //                  ^^^^^^^^^^^ definition local 0
 //                              documentation ```java\nString sectionName\n```
   void stop();
 //     ^^^^ definition semanticdb maven . . com/airbnb/epoxy/Timer#stop().
 //          documentation ```java\npublic abstract void stop()\n```
-//          relationship is_reference is_implementation com/airbnb/epoxy/DebugTimer#stop().
-//          relationship is_reference is_implementation com/airbnb/epoxy/NoOpTimer#stop().
+//          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/DebugTimer#stop().
+//          relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/NoOpTimer#stop().
 }

--- a/tests/snapshots/src/main/generated/tests/minimized-scala/src/main/scala/minimized/Issue413.scala
+++ b/tests/snapshots/src/main/generated/tests/minimized-scala/src/main/scala/minimized/Issue413.scala
@@ -7,12 +7,12 @@ trait Issue413 {
   val b: Int
 //    ^ definition semanticdb maven . . minimized/Issue413#b.
 //      documentation ```scala\nval b: Int\n```
-//      relationship is_reference is_implementation minimized/Issue413Subclass#b.
+//      relationship is_reference is_implementation semanticdb maven . . minimized/Issue413Subclass#b.
 //       ^^^ reference semanticdb maven . . scala/Int#
   val c: Int
 //    ^ definition semanticdb maven . . minimized/Issue413#c.
 //      documentation ```scala\nval c: Int\n```
-//      relationship is_reference is_implementation minimized/Issue413Subclass#c.
+//      relationship is_reference is_implementation semanticdb maven . . minimized/Issue413Subclass#c.
 //       ^^^ reference semanticdb maven . . scala/Int#
 }
 object Issue413 {

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AbstractClasses.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AbstractClasses.java
@@ -16,5 +16,5 @@ public abstract class AbstractClasses {
 //                ^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
 //                       ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/AbstractClasses#abstractImplementation().
 //                                              documentation ```java\npublic abstract String abstractImplementation()\n```
-//                                              relationship is_reference is_implementation minimized/SubClasses#abstractImplementation().
+//                                              relationship is_reference is_implementation semanticdb maven . . minimized/SubClasses#abstractImplementation().
 }

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/InnerClasses.java
@@ -60,7 +60,7 @@ public class InnerClasses {
 //  ^ reference semanticdb maven . . minimized/InnerClasses#InnerInterface#[B]
 //    ^^^^^ definition semanticdb maven . . minimized/InnerClasses#InnerInterface#apply().
 //          documentation ```java\npublic abstract B apply(A a)\n```
-//          relationship is_reference is_implementation minimized/InnerClasses#InnerClass#apply().
+//          relationship is_reference is_implementation semanticdb maven . . minimized/InnerClasses#InnerClass#apply().
 //          ^ reference semanticdb maven . . minimized/InnerClasses#InnerInterface#[A]
 //            ^ definition local 1
 //              documentation ```java\nA a\n```

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/Interfaces.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/Interfaces.java
@@ -11,7 +11,7 @@ public interface Interfaces {
 //^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
 //       ^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/Interfaces#abstractInterfaceMethod().
 //                               documentation ```java\npublic abstract String abstractInterfaceMethod()\n```
-//                               relationship is_reference is_implementation minimized/SubClasses#abstractInterfaceMethod().
+//                               relationship is_reference is_implementation semanticdb maven . . minimized/SubClasses#abstractInterfaceMethod().
 
   default String defaultInterfaceMethod() {
 //        ^^^^^^ reference semanticdb maven jdk 11 java/lang/String#

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/TypeVariables.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/TypeVariables.java
@@ -31,7 +31,7 @@ public class TypeVariables {
     void mI();
 //       ^^ definition semanticdb maven . . minimized/TypeVariables#I#mI().
 //          documentation ```java\npublic abstract void mI()\n```
-//          relationship is_reference is_implementation minimized/TypeVariables#CT#mI().
+//          relationship is_reference is_implementation semanticdb maven . . minimized/TypeVariables#CT#mI().
   }
 
   static class CT extends C implements I {

--- a/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
+++ b/tests/snapshots/src/main/generated/ujson/IndexedValue.scala
@@ -34,14 +34,14 @@ sealed trait IndexedValue {
   def index: Int
 //    ^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue#index().
 //          documentation ```scala\ndef index: Int\n```
-//          relationship is_reference is_implementation ujson/IndexedValue.Arr#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.False#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.Null#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.Num#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.NumRaw#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.Obj#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.Str#index.
-//          relationship is_reference is_implementation ujson/IndexedValue.True#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.Arr#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.False#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.Null#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.Num#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.NumRaw#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.Obj#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.Str#index.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.True#index.
 //           ^^^ reference semanticdb maven maven/org.scala-lang/scala-library 2.13.10 scala/Int#
 }
 

--- a/tests/snapshots/src/main/generated/ujson/JsVisitor.scala
+++ b/tests/snapshots/src/main/generated/ujson/JsVisitor.scala
@@ -26,11 +26,11 @@ trait JsVisitor[-T, +J] extends Visitor[T, J]{
   def visitFloat64(d: Double, index: Int): J = {
 //    ^^^^^^^^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/JsVisitor#visitFloat64().
 //                 documentation ```scala\ndef visitFloat64(d: Double, index: Int): J\n```
+//                 relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/BaseByteRenderer#visitFloat64().
+//                 relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/BaseCharRenderer#visitFloat64().
+//                 relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.Builder.visitFloat64().
+//                 relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.visitFloat64().
 //                 relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/upickle-core_2.13 1.4.0 upickle/core/Visitor#visitFloat64().
-//                 relationship is_reference is_implementation ujson/BaseByteRenderer#visitFloat64().
-//                 relationship is_reference is_implementation ujson/BaseCharRenderer#visitFloat64().
-//                 relationship is_reference is_implementation ujson/IndexedValue.Builder.visitFloat64().
-//                 relationship is_reference is_implementation ujson/Value.visitFloat64().
 //                 ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/JsVisitor#visitFloat64().(d)
 //                   documentation ```scala\nd: Double \n```
 //                    ^^^^^^ reference semanticdb maven maven/org.scala-lang/scala-library 2.13.10 scala/Double#

--- a/tests/snapshots/src/main/generated/ujson/Readable.scala
+++ b/tests/snapshots/src/main/generated/ujson/Readable.scala
@@ -22,8 +22,8 @@ trait Readable {
   def transform[T](f: Visitor[_, T]): T
 //    ^^^^^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Readable#transform().
 //              documentation ```scala\ndef transform(f: Visitor[local0, T[): T\n```
-//              relationship is_reference is_implementation ujson/Readable.fromTransformer#transform().
-//              relationship is_reference is_implementation ujson/Value#transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Readable.fromTransformer#transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value#transform().
 //              ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Readable#transform().[T]
 //                documentation ```scala\nT\n```
 //                 ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Readable#transform().(f)

--- a/tests/snapshots/src/main/generated/ujson/Transformer.scala
+++ b/tests/snapshots/src/main/generated/ujson/Transformer.scala
@@ -14,13 +14,13 @@ trait Transformer[I] {
   def transform[T](j: I, f: Visitor[_, T]): T
 //    ^^^^^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Transformer#transform().
 //              documentation ```scala\ndef transform(j: I, f: Visitor[local0, T[): T\n```
-//              relationship is_reference is_implementation ujson/ByteArrayParser.transform().
-//              relationship is_reference is_implementation ujson/ByteBufferParser.transform().
-//              relationship is_reference is_implementation ujson/CharSequenceParser.transform().
-//              relationship is_reference is_implementation ujson/IndexedValue.transform().
-//              relationship is_reference is_implementation ujson/InputStreamParser.transform().
-//              relationship is_reference is_implementation ujson/StringParser.transform().
-//              relationship is_reference is_implementation ujson/Value.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/ByteArrayParser.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/ByteBufferParser.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/CharSequenceParser.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/IndexedValue.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/InputStreamParser.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/StringParser.transform().
+//              relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.transform().
 //              ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Transformer#transform().[T]
 //                documentation ```scala\nT\n```
 //                 ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Transformer#transform().(j)

--- a/tests/snapshots/src/main/generated/ujson/Value.scala
+++ b/tests/snapshots/src/main/generated/ujson/Value.scala
@@ -43,14 +43,14 @@ sealed trait Value extends Readable with geny.Writable{
   def value: Any
 //    ^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value#value().
 //          documentation ```scala\ndef value: Any\n```
-//          relationship is_reference is_implementation ujson/Arr#value.
-//          relationship is_reference is_implementation ujson/Bool#value().
-//          relationship is_reference is_implementation ujson/False.value().
-//          relationship is_reference is_implementation ujson/Null.value().
-//          relationship is_reference is_implementation ujson/Num#value.
-//          relationship is_reference is_implementation ujson/Obj#value.
-//          relationship is_reference is_implementation ujson/Str#value.
-//          relationship is_reference is_implementation ujson/True.value().
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Arr#value.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Bool#value().
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/False.value().
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Null.value().
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Num#value.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Obj#value.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Str#value.
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/True.value().
 //           ^^^ reference semanticdb maven . . scala/Any#
 
   /**
@@ -368,8 +368,8 @@ object Value extends AstTransformer[Value]{
     def apply(x: Value): Value
 //      ^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector#apply().
 //            documentation ```scala\ndef apply(x: Value): Value\n```
-//            relationship is_reference is_implementation ujson/Value.Selector.IntSelector#apply().
-//            relationship is_reference is_implementation ujson/Value.Selector.StringSelector#apply().
+//            relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector.IntSelector#apply().
+//            relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector.StringSelector#apply().
 //            ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector#apply().(x)
 //              documentation ```scala\nx: Value \n```
 //               ^^^^^ reference semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Value#
@@ -377,8 +377,8 @@ object Value extends AstTransformer[Value]{
     def update(x: Value, y: Value): Unit
 //      ^^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector#update().
 //             documentation ```scala\ndef update(x: Value, y: Value): Unit\n```
-//             relationship is_reference is_implementation ujson/Value.Selector.IntSelector#update().
-//             relationship is_reference is_implementation ujson/Value.Selector.StringSelector#update().
+//             relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector.IntSelector#update().
+//             relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector.StringSelector#update().
 //             ^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Selector#update().(x)
 //               documentation ```scala\nx: Value \n```
 //                ^^^^^ reference semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value.Value#
@@ -1366,9 +1366,9 @@ sealed abstract class Bool extends Value{
   def value: Boolean
 //    ^^^^^ definition semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Bool#value().
 //          documentation ```scala\ndef value: Boolean\n```
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/False.value().
+//          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/True.value().
 //          relationship is_reference is_implementation semanticdb maven maven/com.lihaoyi/ujson_2.13 1.4.0 ujson/Value#value().
-//          relationship is_reference is_implementation ujson/False.value().
-//          relationship is_reference is_implementation ujson/True.value().
 //           ^^^^^^^ reference semanticdb maven maven/org.scala-lang/scala-library 2.13.10 scala/Boolean#
 }
 object Bool{


### PR DESCRIPTION
Uploading an index with scip-java v0.8.17 results in the following error in the Sourcegraph UI

```
codeNavSvc.GetImplementations: lsifStore.MonikersByPosition: reached end of symbol while parsing <scheme>, expected a ' ' character
minimized/Issue413Subclass#c.
_____________________________^
```
<img width="1237" alt="CleanShot 2023-05-02 at 13 43 46@2x" src="https://user-images.githubusercontent.com/1408093/235656945-12d2ba00-c553-49e6-83eb-46983e4104e0.png">

The problem is that this release introduced a regression where scip-java emitted invalid SCIP symbols. This PR fixes the issue, and adds new checks in the testing infrastructure to prevent this kind of regression from happening again.

### Test plan

See updated snapshots.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
