### PR TITLE
deps: bump mill-scip to 0.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val V =
     def testcontainers = "0.39.3"
     def requests = "0.6.5"
     def minimalMillVersion = "0.10.0"
-    def millScipVersion = "0.3.0"
+    def millScipVersion = "0.3.2"
   }
 
 inThisBuild(


### PR DESCRIPTION
This just ensure the version of mill-scip being used has the latest
improvements from semanticdbJava and also this version starts cross
publishing for 0.11.x milestones of Mill.

### Test plan

The existing Mill tests should still be passing. When 0.11.0 is added we can
also add that to the test matrix, but for now I left it as is.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
