### PR TITLE
Set all directories as "safe" for Git in the indexer docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,18 @@ jobs:
           distribution: "temurin"
           cache: "sbt"
           java-version: ${{ matrix.java }}
-      - run: sbt test
+      - run: sbt test cli/docker
+
+      - name: Docker integration tests
+        run: |
+          gh repo clone scalameta/munit
+          gh repo clone circe/circe
+
+          docker run -v $PWD:/sources -w /sources sourcegraph/scip-java:latest index
+          file index.scip || (echo "index.scip doesn't exist!"; exit 1) 
+          
+          docker run -v $PWD:/sources -w /sources sourcegraph/scip-java:latest index
+          file index.scip || (echo "index.scip doesn't exist!"; exit 1) 
   bazel:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -271,6 +271,11 @@ lazy val cli = project
         env("PATH", "/opt/maven/bin:${PATH}")
         env("PATH", "/root/.local/share/coursier/bin:${PATH}")
 
+        // Mark all directories as safe for Git, so that it doesn't
+        // trigger this check and error:
+        // `detected dubious ownership in repository at <folder>`
+        run("git", "config", "--global", "--add", "safe.directory", "*")
+
         // Install `scip-java` binary.
         add(scipJavaWrapper, "/usr/local/bin/scip-java")
         add(binaryDistribution, "/app/scip-java")


### PR DESCRIPTION
_stand by for description_

### Test plan

- Manual testing
- Add a Docker integration test to CI with repos that use sbt-dynver

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
