### PR TITLE
Auto build tool - choose the first one that applies

### DIFF
--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BuildTool.scala
@@ -20,10 +20,28 @@ abstract class BuildTool(val name: String, index: IndexCommand) {
 object BuildTool {
   def all(index: IndexCommand): List[BuildTool] =
     List(
+      new ScipBuildTool(index),
       new BazelBuildTool(index),
       new GradleBuildTool(index),
       new MavenBuildTool(index),
+      new SbtBuildTool(index),
+      new MillBuildTool(index)
+    )
+
+  def autoOrdered(index: IndexCommand): List[BuildTool] =
+    List(
+      // The order in this list is important -
+      // first detected build tool will be used in `auto` mode
+      // Bazel is missing because it isn't supported by auto-indexing
+
+      // first as it indicates user's intent to use SCIP auto-indexing
       new ScipBuildTool(index),
+      // Maven first, then Gradle, then SBT
+      // To match the order indicated in IntelliJ Java and Scala developer surveys 2022:
+      // 1. https://www.jetbrains.com/lp/devecosystem-2022/java/#which-build-systems-do-you-regularly-use-if-any-
+      // 2. https://www.jetbrains.com/lp/devecosystem-2022/scala/#which-build-systems-do-you-regularly-use-if-any-
+      new MavenBuildTool(index),
+      new GradleBuildTool(index),
       new SbtBuildTool(index),
       new MillBuildTool(index)
     )

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BuildTool.scala
@@ -19,14 +19,9 @@ abstract class BuildTool(val name: String, index: IndexCommand) {
 
 object BuildTool {
   def all(index: IndexCommand): List[BuildTool] =
-    List(
-      new ScipBuildTool(index),
-      new BazelBuildTool(index),
-      new GradleBuildTool(index),
-      new MavenBuildTool(index),
-      new SbtBuildTool(index),
-      new MillBuildTool(index)
-    )
+    // We don't support Bazel for auto-indexing, but if it's
+    // detected, we should at least give a meaningful error message
+    autoOrdered(index) :+ new BazelBuildTool(index)
 
   def autoOrdered(index: IndexCommand): List[BuildTool] =
     List(

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/GradleBuildTool.scala
@@ -15,10 +15,14 @@ import os.CommandResult
 class GradleBuildTool(index: IndexCommand) extends BuildTool("Gradle", index) {
 
   override def usedInCurrentDirectory(): Boolean = {
-    Files.isRegularFile(index.workingDirectory.resolve("settings.gradle")) ||
-    Files.isRegularFile(index.workingDirectory.resolve("gradlew")) ||
-    Files.isRegularFile(index.workingDirectory.resolve("build.gradle")) ||
-    Files.isRegularFile(index.workingDirectory.resolve("build.gradle.kts"))
+    val gradleFiles = List(
+      "settings.gradle",
+      "gradlew",
+      "build.gradle",
+      "build.gradle.kts"
+    )
+    gradleFiles
+      .exists(name => Files.isRegularFile(index.workingDirectory.resolve(name)))
   }
 
   override def generateScip(): Int = {

--- a/tests/buildTools/src/test/scala/tests/AutoBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/AutoBuildToolSuite.scala
@@ -1,0 +1,11 @@
+package tests
+
+class AutoBuildToolSuite extends BaseBuildToolSuite {
+  checkErrorOutput(
+    "no-tools-found",
+    List("index", "--build-tool", "auto"),
+    expectedOutput =
+      """error: Build tool mode set to `auto`, but no supported build tools were detected""",
+    workingDirectoryLayout = ""
+  )
+}

--- a/tests/buildTools/src/test/scala/tests/MissingBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MissingBuildToolSuite.scala
@@ -6,7 +6,7 @@ class MissingBuildToolSuite extends BaseBuildToolSuite {
     "basic",
     List("index"),
     expectedOutput =
-      s"""|error: No build tool detected in workspace '${java.io.File.separator}workingDirectory'. At the moment, the only supported build tools are: Gradle, Maven, sbt, mill.
+      s"""|error: No build tool detected in workspace '${java.io.File.separator}workingDirectory'. At the moment, the only supported build tools are: Maven, Gradle, sbt, mill.
           |""".stripMargin,
     workingDirectoryLayout = ""
   )
@@ -15,7 +15,7 @@ class MissingBuildToolSuite extends BaseBuildToolSuite {
     "ambiguous",
     List("index"),
     expectedOutput =
-      """|error: Multiple build tools detected: Gradle, Maven. To fix this problem, use the '--build-tool=BUILD_TOOL_NAME' flag to specify which build tool to run.
+      """|error: Multiple build tools detected: Maven, Gradle. To fix this problem, use the '--build-tool=BUILD_TOOL_NAME' flag to specify which build tool to run.
          |""".stripMargin,
     workingDirectoryLayout =
       """|/pom.xml


### PR DESCRIPTION
To simplify the inference rules, we are providing `--build-tool=auto` mode which selects first matching tool from a list.

The list itself is ordered by relative popularity according to Jetbrains' surveys likethis: https://www.jetbrains.com/lp/devecosystem-2022/scala/#which-build-systems-do-you-regularly-use-if-any-

### Test plan

N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
