### PR TITLE
Try different jdk versions in sequence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,15 @@ jobs:
         run: sbt cli/docker
 
       - run: |
-          git clone https://github.com/circe/circe.git
+          set -eu
+          for REPO in circe/circe indeedeng/proctor
+          do 
+            mkdir -p .repos/$REPO
+            git clone https://github.com/$REPO.git .repos/$REPO
 
-          docker run -v $PWD:/sources -w /sources sourcegraph/scip-java:latest scip-java index --cwd circe
-          file circe/index.scip || (echo "circe SCIP index doesn't exist!"; exit 1) 
+            docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
+            file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1) 
+          done
 
   bazel:
     runs-on: ubuntu-latest

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -13,3 +13,9 @@ curl -fLo gradle.zip https://services.gradle.org/distributions/gradle-7.6.1-bin.
 unzip -d /opt/gradle gradle.zip 
 rm gradle.zip
 mv /opt/gradle/*/* /opt/gradle
+
+# pre-install JDK for all major versions
+for JVM_VERSION in 17 11 8
+do 
+  coursier java --jvm $JVM_VERSION --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json -- -version
+done

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -6,6 +6,10 @@ coursier setup --yes
 
 curl -fLo maven.zip https://archive.apache.org/dist/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.zip 
 unzip -d /opt/maven maven.zip
+rm maven.zip
 mv /opt/maven/*/* /opt/maven
 
-rm maven.zip
+curl -fLo gradle.zip https://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+unzip -d /opt/gradle gradle.zip 
+rm gradle.zip
+mv /opt/gradle/*/* /opt/gradle

--- a/bin/scip-java-docker-script.sh
+++ b/bin/scip-java-docker-script.sh
@@ -3,7 +3,7 @@
 # version. It assumes that `coursier` is available on the `$PATH` and that the
 # `scip-java` binary is already installed at `/app/scip-java/bin/scip-java`.
 set -eu
-JVM_VERSION="${JVM_VERSION:-17}"
+JVM_VERSION="${JVM_VERSION:-17,11,8}"
 FILE="$PWD/lsif-java.json"
 if test -f "$FILE"; then
 	FROM_CONFIG=$(jq -r '.jvm' "$FILE")
@@ -12,13 +12,33 @@ if test -f "$FILE"; then
 	fi
 fi
 
-echo "Using JVM version '$JVM_VERSION'"
+JVM_VERSIONS=$(echo $JVM_VERSION | tr "," "\n")
 
-if [ "$JVM_VERSION" = "17" ]; then
-  export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-  # No need to download Java 17 because it's pre-installed.
-else
-  eval "$(coursier java --jvm "$JVM_VERSION" --env --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json)"
-fi
+LAST_CODE="-1"
 
-/app/scip-java/bin/scip-java "$@"
+ARGS=$@
+
+for JVM_VERSION in $JVM_VERSIONS
+do 
+	if [ "$LAST_CODE" != "0" ]; then
+		echo "Using JVM version '$JVM_VERSION'"
+
+		if [ "$JVM_VERSION" = "17" ]; then
+			export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+		else
+			export JAVA_OPTS=""
+		fi
+
+		eval "$(coursier java --jvm "$JVM_VERSION" --env --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json)"
+
+		java -version
+		if /app/scip-java/bin/scip-java "$@"; then 
+			LAST_CODE="0"
+		else 
+			LAST_CODE=$?
+		fi
+
+	fi
+done
+
+exit $LAST_CODE

--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,7 @@ lazy val cli = project
       val dockerSetup = (ThisBuild / baseDirectory).value / "bin" /
         "docker-setup.sh"
       new Dockerfile {
-        from("gradle:7.2.0-jdk17")
+        from("eclipse-temurin:17")
 
         // Setup system dependencies.
         run("apt-get", "update")
@@ -316,6 +316,7 @@ lazy val cli = project
         run("bash", "/docker-setup.sh")
 
         env("PATH", "/opt/maven/bin:${PATH}")
+        env("PATH", "/opt/gradle/bin:${PATH}")
         env("PATH", "/root/.local/share/coursier/bin:${PATH}")
 
         // Mark all directories as safe for Git, so that it doesn't


### PR DESCRIPTION
- Preload JDK 17, 11, 8 into the container
- Try each one until the indexing succeeds

The order might be wrong, may be should swing wildly - 17, then 8, then 11.

This change allows indexing https://github.com/indeedeng/proctor - first it tries 17 and 11, fails on both, then 8, produces a valid SCIP index.

Additionally:
- Switch to a base JDK 17 image
- Install Gradle the same way we install Maven, for consistency

  This also removes gradle from being the entrypoint of the docker image, which was confusing
  Good time to make `scip-java` itself the entry point

### Test plan

- Add problematic repo to docker CLI test list

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
