### PR TITLE
Check annotation path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,21 @@ jobs:
         run: sbt cli/docker
 
       - run: |
+
           set -eu
-          for REPO in circe/circe indeedeng/proctor
-          do 
+          check_repo() {
+            REPO=$1
             mkdir -p .repos/$REPO
             git clone https://github.com/$REPO.git .repos/$REPO
 
             docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
             file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1) 
-          done
+          }
+          
+          sudo apt install parallel
+          export -f check_repo
+
+          parallel -j4 check_repo ::: circe/circe indeedeng/proctor indeedend/iwf-java-sdk
 
   bazel:
     runs-on: ubuntu-latest

--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -59,9 +59,25 @@ class SemanticdbGradlePlugin extends Plugin[Project] {
         triggers += "compileJava"
         triggers += "compileTestJava"
 
+        val hasAnnotationPath = {
+          var result = false
+          tasks
+            .withType(classOf[JavaCompile])
+            .configureEach { task =>
+              result =
+                result ||
+                  !task.getOptions().getAnnotationProcessorPath().isEmpty()
+            }
+
+          result
+
+        }
+
         val compilerPluginAdded =
           try {
             project.getDependencies().add("compileOnly", javacDep)
+            if (hasAnnotationPath)
+              project.getDependencies().add("annotationProcessor", javacDep)
             project.getDependencies().add("testCompileOnly", javacDep)
             true
           } catch {


### PR DESCRIPTION
If annotation processors are used, then compileOnly classpath is ignored entirely.

We attempt to add the plugin to that, but if it fails - it gives us a clear signal to go back to agents instead.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
