### PR TITLE
Set higher RAM percentage in Docker container

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -318,6 +318,10 @@ lazy val cli = project
         env("PATH", "/opt/maven/bin:${PATH}")
         env("PATH", "/opt/gradle/bin:${PATH}")
         env("PATH", "/root/.local/share/coursier/bin:${PATH}")
+        env(
+          "JAVA_TOOL_OPTIONS",
+          "-XX:MaxRAMPercentage=80.0 -XX:+UseContainerSupport"
+        )
 
         // Mark all directories as safe for Git, so that it doesn't
         // trigger this check and error:


### PR DESCRIPTION
On larger Scala/Java projects (I'm using https://github.com/lichess-org/lila it's a very good stress test), SBT's default heap is way too small (1GB), especially if we don't set any concurrency as part of the sbt-sourcegraph plugin (IMO we should)

To give the containers more oomph, we set the special JAVA_TOOL_OPTIONS variable: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html

1. Set max RAM percentage to be higher
2. Use Container support flag: https://www.eclipse.org/openj9/docs/xxusecontainersupport/
   
   This will adjust the max available RAM accordingly

### Test plan

Manual testing on large projects 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
