### PR TITLE
Publish a `latest-snapshot` docker image from main

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,6 +1,8 @@
 name: Release Docker
 on:
   push:
+    branches:
+      - main
     tags: ["*"]
 jobs:
   publish:

--- a/build.sbt
+++ b/build.sbt
@@ -272,11 +272,28 @@ lazy val cli = project
           propsFile :: copiedJars.toList
         }
         .taskValue,
-    docker / imageNames :=
-      List(
-        ImageName("sourcegraph/scip-java:latest"),
-        ImageName(s"sourcegraph/scip-java:${version.value}")
-      ),
+    docker / imageNames := {
+      val latest = {
+        val label =
+          if (isSnapshot.value)
+            "latest-snapshot"
+          else
+            "latest"
+
+        List(ImageName(s"sourcegraph/scip-java:$label"))
+      }
+
+      // Don't publish a separately tagged image for snapshots -
+      // only latest-snapshot
+      val versioned =
+        if (isSnapshot.value)
+          Nil
+        else
+          List(ImageName(s"sourcegraph/scip-java:${version.value}"))
+
+      latest ++ versioned
+
+    },
     docker / dockerfile := {
       val binaryDistribution = pack.value
       val scipJavaWrapper = (ThisBuild / baseDirectory).value / "bin" /


### PR DESCRIPTION
This is a proposal for faster iteration loops - we can use the `latest-snapshot` version when debugging some issue iteratively.

- On merges to `main` only `:latest-snapshot` will be published
- On tags, `:latest` and `:<version>` will be published

### Test plan

N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
