### PR TITLE
feat: add support for 0.11.x series of Mill

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val V =
     val testcontainers = "0.39.3"
     val requests = "0.6.5"
     val minimalMillVersion = "0.10.0"
-    val millScipVersion = "0.3.2"
+    val millScipVersion = "0.3.4"
     val kotlinGradlePlugin = "1.5.31"
   }
 

--- a/tests/buildTools/src/test/scala/tests/MillBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MillBuildToolSuite.scala
@@ -50,7 +50,7 @@ class MillBuildToolSuite extends BaseBuildToolSuite {
     else
       "idn fail, we don't cover this scala version"
 
-  val supportedMillVersions = List("0.10.0")
+  val supportedMillVersions = List("0.10.6", "0.11.0")
   val supportedScalaVersion = List("2.12.16", "2.13.8", "3.1.3")
 
   val testGroupings =
@@ -68,7 +68,7 @@ class MillBuildToolSuite extends BaseBuildToolSuite {
           |import mill._, scalalib._
           |object minimal extends ScalaModule {
           |  def scalaVersion = "${scalaVersion}"
-          |  object test extends Tests with TestModule.Munit {
+          |  object test extends ScalaModuleTests with TestModule.Munit {
           |    def ivyDeps = Agg(ivy"org.scalameta::munit:1.0.0-M6")
           | }
           |}


### PR DESCRIPTION
This bumps the version of mill-scip which brings in support for the newly released 0.11.x series of Mill. This also updates the tests to ensure they are running against both the minimal 0.10.x and 0.11.x versions of Mill.

### Test plan

Tests should all be 🍏 .
