### PR TITLE
Bazel: add support for DirectoryFileObject

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -328,9 +328,8 @@ projects, with the following caveats:
 
 ### Bazel
 
-Bazel is supported by scip-java but it requires custom configuration to work
-correctly. Note that the `scip-java index` command does not automatically index
-Bazel builds.
+Bazel is supported by scip-java, but it requires custom configuration to work
+correctly. The `scip-java index` command does not automatically index Bazel builds.
 
 The Bazel integration for scip-java is specifically designed to be compatible
 with the Bazel build cache to enable incremental indexing. To achieve this,
@@ -342,6 +341,38 @@ repository contains an example for how to configure everything.
 - [BUILD](https://github.com/sourcegraph/scip-java/blob/main/examples/bazel-example/src/main/java/example/BUILD):
   configured `java_library` and `java_binary` targets to be indexed with
   scip-java.
+
+Once configured, build the codebase with the SemanticDB compiler plugin.
+```sh
+bazel build //... --@scip_java//semanticdb-javac:enabled=true
+```
+
+Next, run the following command to generate the SCIP index (`index.scip`).
+
+```
+bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot $PWD
+
+# (optional) Validate that SemanticDB files were generated.
+# The command below works for the `examples/bazel-example` directory in the sourcegraph/scip-java repository.
+❯ jar tf bazel-bin/src/main/java/example/libexample.jar | grep semanticdb$
+META-INF/semanticdb/src/main/java/example/Example.java.semanticdb
+ ```
+
+Finally, run the following commands to upload the SCIP index to Sourcegraph.
+
+```
+# 1. Install src
+npm install -g @sourcegraph/src # Or yarn global add @sourcegraph/src
+
+# 2. Authenticate with Sourcegraph
+export SRC_ACCESS_TOKEN=sgp_YOUR_ACCESS_TOKEN
+export SRC_ENDPOINT=https://sourcegraph.example.com
+src login # validate the token authenticates correctly
+
+# 3. Upload SCIP index to Sourcegraph
+src code-intel upload # requires index.scip file to exist
+```
+
 
 Don't hesitate to open an issue in the
 [scip-java repository](https://github.com/sourcegraph/scip-java) if you have any


### PR DESCRIPTION
Previously, the scip-java Bazel support only supported SimpleFileObject in the Java compiler API and it crashed when encountering other types of file objects like DirectoryFileObject, which are used in some Bazel builds in the wild. This commit adds support for DirectoryFileObject.

Additionally, this commit adds more detailed documentation on how to use scip-java with Bazel.

### Test plan

Green CI.

Manually tested there was no regression in the steps below
```
❯ bazel build //... --@scip_java//semanticdb-javac:enabled=true
INFO: Build option --@scip_java//semanticdb-javac:enabled has changed, discarding analysis cache.
INFO: Analyzed target //src/main/java/example:example (0 packages loaded, 843 targets configured).
INFO: Found 1 target...
Target //src/main/java/example:example up-to-date:
  bazel-bin/src/main/java/example/libexample.jar
INFO: Elapsed time: 0.152s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

❯ bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot $PWD
INFO: Build option --@scip_java//semanticdb-javac:enabled has changed, discarding analysis cache.
INFO: Analyzed target @scip_java//scip-semanticdb:bazel (0 packages loaded, 863 targets configured).
INFO: Found 1 target...
Target @scip_java//scip-semanticdb:bazel up-to-date:
  bazel-bin/external/scip_java/scip-semanticdb/bazel.jar
  bazel-bin/external/scip_java/scip-semanticdb/bazel
INFO: Elapsed time: 0.184s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/external/scip_java/scip-semanticdb/bazel --sourceroot /Users/olafurpg/dev/sourcegraph/scip-java/examples
INFO: Build completed successfully, 1 total action
running: bazel query kind('.*_import', @maven//...) --output=proto
done: /Users/olafurpg/dev/sourcegraph/scip-java/examples/bazel-example/index.scip
```
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
