### PR TITLE
bzl: add http_archive to bazel-example

### DIFF
--- a/examples/bazel-example/WORKSPACE
+++ b/examples/bazel-example/WORKSPACE
@@ -22,7 +22,15 @@ local_repository(
     name = "scip_java",
     path = "../.."
 )
-# TODO: add commented out `http_archive` example once this workspace file is available on GitHub.
+
+# Copy and paste this, not the local_repository:
+# 
+# SCIP_JAVA_VERSION="0.8.20"
+# http_archive(
+#   name = "scip_java",
+#   url = "https://github.com/sourcegraph/scip-java/archive/refs/tags/v{}.zip".format(SCIP_JAVA_VERSION),
+#   strip_prefix = "scip-java-{}".format(SCIP_JAVA_VERSION),
+# )
 
 ##########
 # Protobuf


### PR DESCRIPTION
The `http_archive` rule was missing which can lead to confusing errors when the users tries to write the rule themselves and forget about `strip_prefix`, as the `.bazelignore` from this repo will suddenly stop matching the `examples` folder, leading to build errors about the example itself. 

### Test plan

Tested with the example repo from bazel/java docs. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
