### PR TITLE
Special handling of Bazel with source generators

### DIFF
--- a/examples/bazel-example/WORKSPACE
+++ b/examples/bazel-example/WORKSPACE
@@ -69,7 +69,9 @@ maven_install(
     artifacts = [
         "com.google.protobuf:protobuf-java:3.15.6", # Required dependency by scip-java.
         "com.google.protobuf:protobuf-java-util:3.15.6", # Required dependency by scip-java.
-        "com.google.guava:guava:31.0-jre", # Not required dependency, only used by tests.
+        # These dependencies are only required for the tests
+        "com.google.guava:guava:31.0-jre", 
+        "com.google.auto.value:auto-value:1.5.3",
     ],
     repositories = [
          "https://repo1.maven.org/maven2",

--- a/examples/bazel-example/src/main/java/source-generator-example/Animal.java
+++ b/examples/bazel-example/src/main/java/source-generator-example/Animal.java
@@ -1,0 +1,12 @@
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+abstract class Animal {
+  static Animal create(String name, int numberOfLegs) {
+    return new AutoValue_Animal(name, numberOfLegs);
+  }
+
+  abstract String name();
+  abstract int numberOfLegs();
+}

--- a/examples/bazel-example/src/main/java/source-generator-example/BUILD
+++ b/examples/bazel-example/src/main/java/source-generator-example/BUILD
@@ -1,0 +1,34 @@
+load("@scip_java//semanticdb-javac:defs.bzl", "java_library")
+load("@rules_java//java:defs.bzl", "java_plugin")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+java_library(
+	name = "animal",
+	srcs = ["Animal.java"],
+	deps = [
+    ":autovalue",
+	],
+)
+
+java_plugin(
+    name = "autovalue_plugin",
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = [
+        "@maven//:com_google_auto_value_auto_value",
+    ],
+)
+
+java_library(
+    name = "autovalue",
+    exported_plugins = [
+        ":autovalue_plugin",
+    ],
+    neverlink = 1,
+    exports = [
+        "@maven//:com_google_auto_value_auto_value",
+    ],
+)
+

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
@@ -45,6 +45,7 @@ public class SemanticdbJavacOptions {
 
   public static SemanticdbJavacOptions parse(String[] args, Context ctx) {
     SemanticdbJavacOptions result = new SemanticdbJavacOptions();
+
     boolean useJavacClassesDir = false;
     for (String arg : args) {
       if (arg.startsWith("-targetroot:")) {
@@ -122,6 +123,6 @@ public class SemanticdbJavacOptions {
               JAVAC_CLASSES_DIR_ARG, out.toString());
       result.errors.add(errorMsg);
     }
-    return new TargetPaths(classOutputDir, sourceOutputDir);
+    return (new TargetPaths(classOutputDir, sourceOutputDir));
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
@@ -123,6 +123,6 @@ public class SemanticdbJavacOptions {
               JAVAC_CLASSES_DIR_ARG, out.toString());
       result.errors.add(errorMsg);
     }
-    return (new TargetPaths(classOutputDir, sourceOutputDir));
+    return new TargetPaths(classOutputDir, sourceOutputDir);
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbReporter.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbReporter.java
@@ -31,6 +31,10 @@ public class SemanticdbReporter {
     trees.printMessage(Diagnostic.Kind.ERROR, baos.toString(), tree, root);
   }
 
+  public void exception(Throwable e, TaskEvent task) {
+    this.exception(e, task.getCompilationUnit(), task.getCompilationUnit());
+  }
+
   public void info(String message, TaskEvent e) {
     trees.printMessage(
         Diagnostic.Kind.NOTE,

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbReporter.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbReporter.java
@@ -12,44 +12,47 @@ import java.io.PrintWriter;
 /**
  * Utilities to report error messages.
  *
- * <p>
- * NOTE(olafur): this class exists because I couldn't find compiler APIs to
- * report diagnostics. This class can be removed if the Java compiler has APIs
- * to report info/warning/error messages.
+ * <p>NOTE(olafur): this class exists because I couldn't find compiler APIs to report diagnostics.
+ * This class can be removed if the Java compiler has APIs to report info/warning/error messages.
  */
 public class SemanticdbReporter {
-	private final Trees trees;
+  private final Trees trees;
 
-	public SemanticdbReporter(Trees trees) {
-		this.trees = trees;
-	}
+  public SemanticdbReporter(Trees trees) {
+    this.trees = trees;
+  }
 
-	public void exception(Throwable e, Tree tree, CompilationUnitTree root) {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		PrintWriter writer = new PrintWriter(baos);
-		e.printStackTrace(writer);
-		writer.println(
-				"Please report a bug to https://github.com/sourcegraph/semanticdb-java with the stack trace above.");
-		trees.printMessage(Diagnostic.Kind.ERROR, baos.toString(), tree, root);
-	}
+  public void exception(Throwable e, Tree tree, CompilationUnitTree root) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintWriter writer = new PrintWriter(baos);
+    e.printStackTrace(writer);
+    writer.println(
+        "Please report a bug to https://github.com/sourcegraph/semanticdb-java with the stack trace above.");
+    trees.printMessage(Diagnostic.Kind.ERROR, baos.toString(), tree, root);
+  }
 
-	private void info(String message, TaskEvent e) {
-		trees.printMessage(Diagnostic.Kind.NOTE, "semanticdb-javac: " + message, e.getCompilationUnit(),
-				e.getCompilationUnit());
-	}
+  public void info(String message, TaskEvent e) {
+    trees.printMessage(
+        Diagnostic.Kind.NOTE,
+        "semanticdb-javac: " + message,
+        e.getCompilationUnit(),
+        e.getCompilationUnit());
+  }
 
-	public void error(String message, TaskEvent e) {
-		trees.printMessage(Diagnostic.Kind.ERROR, "semanticdb-javac: " + message, e.getCompilationUnit(),
-				e.getCompilationUnit());
-	}
+  public void error(String message, TaskEvent e) {
+    trees.printMessage(
+        Diagnostic.Kind.ERROR,
+        "semanticdb-javac: " + message,
+        e.getCompilationUnit(),
+        e.getCompilationUnit());
+  }
 
-	}
-
-	public void error(String message, Tree tree, CompilationUnitTree root) {
-		// NOTE(olafur): ideally, this message should be reported as a compiler
-		// diagnostic, but I dind't
-		// find
-		// the reporter API so the message goes to stderr instead for now.
-		trees.printMessage(Diagnostic.Kind.ERROR, String.format("semanticdb-javac: %s", message), tree, root);
-	}
+  public void error(String message, Tree tree, CompilationUnitTree root) {
+    // NOTE(olafur): ideally, this message should be reported as a compiler
+    // diagnostic, but I dind't
+    // find
+    // the reporter API so the message goes to stderr instead for now.
+    trees.printMessage(
+        Diagnostic.Kind.ERROR, String.format("semanticdb-javac: %s", message), tree, root);
+  }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbReporter.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbReporter.java
@@ -3,6 +3,7 @@ package com.sourcegraph.semanticdb_javac;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.Trees;
+import com.sun.source.util.TaskEvent;
 
 import javax.tools.Diagnostic;
 import java.io.ByteArrayOutputStream;
@@ -11,30 +12,44 @@ import java.io.PrintWriter;
 /**
  * Utilities to report error messages.
  *
- * <p>NOTE(olafur): this class exists because I couldn't find compiler APIs to report diagnostics.
- * This class can be removed if the Java compiler has APIs to report info/warning/error messages.
+ * <p>
+ * NOTE(olafur): this class exists because I couldn't find compiler APIs to
+ * report diagnostics. This class can be removed if the Java compiler has APIs
+ * to report info/warning/error messages.
  */
 public class SemanticdbReporter {
-  private final Trees trees;
+	private final Trees trees;
 
-  public SemanticdbReporter(Trees trees) {
-    this.trees = trees;
-  }
+	public SemanticdbReporter(Trees trees) {
+		this.trees = trees;
+	}
 
-  public void exception(Throwable e, Tree tree, CompilationUnitTree root) {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    PrintWriter writer = new PrintWriter(baos);
-    e.printStackTrace(writer);
-    writer.println(
-        "Please report a bug to https://github.com/sourcegraph/semanticdb-java with the stack trace above.");
-    trees.printMessage(Diagnostic.Kind.ERROR, baos.toString(), tree, root);
-  }
+	public void exception(Throwable e, Tree tree, CompilationUnitTree root) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		PrintWriter writer = new PrintWriter(baos);
+		e.printStackTrace(writer);
+		writer.println(
+				"Please report a bug to https://github.com/sourcegraph/semanticdb-java with the stack trace above.");
+		trees.printMessage(Diagnostic.Kind.ERROR, baos.toString(), tree, root);
+	}
 
-  public void error(String message, Tree tree, CompilationUnitTree root) {
-    // NOTE(olafur): ideally, this message should be reported as a compiler diagnostic, but I dind't
-    // find
-    // the reporter API so the message goes to stderr instead for now.
-    trees.printMessage(
-        Diagnostic.Kind.ERROR, String.format("semanticdb-javac: %s", message), tree, root);
-  }
+	private void info(String message, TaskEvent e) {
+		trees.printMessage(Diagnostic.Kind.NOTE, "semanticdb-javac: " + message, e.getCompilationUnit(),
+				e.getCompilationUnit());
+	}
+
+	public void error(String message, TaskEvent e) {
+		trees.printMessage(Diagnostic.Kind.ERROR, "semanticdb-javac: " + message, e.getCompilationUnit(),
+				e.getCompilationUnit());
+	}
+
+	}
+
+	public void error(String message, Tree tree, CompilationUnitTree root) {
+		// NOTE(olafur): ideally, this message should be reported as a compiler
+		// diagnostic, but I dind't
+		// find
+		// the reporter API so the message goes to stderr instead for now.
+		trees.printMessage(Diagnostic.Kind.ERROR, String.format("semanticdb-javac: %s", message), tree, root);
+	}
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -85,7 +85,7 @@ public final class SemanticdbTaskListener implements TaskListener {
                 .buildTextDocument(e.getCompilationUnit());
         writeSemanticdb(e, path.getOrThrow(), textDocument);
       } else {
-        reporter.error(path.getErrorOrThrow(), e)
+        reporter.error(path.getErrorOrThrow(), e);
       }
     }
   }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -59,9 +59,12 @@ public final class SemanticdbTaskListener implements TaskListener {
     try {
       onFinishedAnalyze(e);
     } catch (Throwable ex) {
-      // Catch exceptions because we don't want to stop the compilation even if this plugin has a
-      // bug. We report the full stack trace because it's helpful for bug reports. Exceptions
-      // should only happen in *exceptional* situations and they should be reported upstream.
+      // Catch exceptions because we don't want to stop the compilation even if this
+      // plugin has a
+      // bug. We report the full stack trace because it's helpful for bug reports.
+      // Exceptions
+      // should only happen in *exceptional* situations and they should be reported
+      // upstream.
       Throwable throwable = ex;
       if (e.getSourceFile() != null) {
         throwable =
@@ -110,12 +113,17 @@ public final class SemanticdbTaskListener implements TaskListener {
         throw new IllegalArgumentException("unsupported URI: " + uri);
       }
     } else if (options.uriScheme == UriScheme.BAZEL) {
-      // This solution is hacky, and it would be very nice to use a dedicated API instead.
-      // The Bazel Java compiler constructs `SimpleFileObject/DirectoryFileObject` with a
-      // "user-friendly" name that points to the original source file and an underlying/actual
-      // file path in a temporary directory. We're constrained by having to use only public APIs of
-      // the Java compiler and `toString()` seems to be the only way to access the user-friendly
       String toString = file.toString().replace(":", "/");
+      // This solution is hacky, and it would be very nice to use a dedicated API
+      // instead.
+      // The Bazel Java compiler constructs `SimpleFileObject/DirectoryFileObject`
+      // with a
+      // "user-friendly" name that points to the original source file and an
+      // underlying/actual
+      // file path in a temporary directory. We're constrained by having to use only
+      // public APIs of
+      // the Java compiler and `toString()` seems to be the only way to access the
+      // user-friendly
       // path.
       String[] knownBazelToStringPatterns =
           new String[] {"SimpleFileObject[", "DirectoryFileObject["};
@@ -144,11 +152,11 @@ public final class SemanticdbTaskListener implements TaskListener {
     // /private/var/tmp/com/example/Hello.java
     //
     // We infer sourceroot by iterating the names of both files in reverse order
-    // and stop at the first entry where  the two paths are different. For the
+    // and stop at the first entry where the two paths are different. For the
     // example above, we compare "Hello.java", then "example", then "com", and
     // when we reach "repo" != "tmp" then we guess that "/home/repo" is the
-    // sourceroot. This logic is brittle  and it would be nice to use more
-    // dedicated APIs, but Bazel actively makes an effort to  sandbox
+    // sourceroot. This logic is brittle and it would be nice to use more
+    // dedicated APIs, but Bazel actively makes an effort to sandbox
     // compilation and hide access to the original workspace, which is why we
     // resort to solutions like this.
     int relativePathDepth = 0;
@@ -199,6 +207,7 @@ public final class SemanticdbTaskListener implements TaskListener {
           // TODO:
         }
       }
+
       return Result.error(
           String.format(
               "sourceroot '%s does not contain path '%s'. To fix this problem, update the -sourceroot flag to "

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/TargetPaths.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/TargetPaths.java
@@ -1,0 +1,13 @@
+package com.sourcegraph.semanticdb_javac;
+
+import java.nio.file.Path;
+
+public class TargetPaths {
+  public Path classes;
+  public Path sources;
+
+  public TargetPaths(Path classesDir, Path sourcesDir) {
+    classes = classesDir;
+    sources = sourcesDir;
+  }
+}


### PR DESCRIPTION
The original issue was reported by a customer on a private codebase, and amounted to the usage of source generators crashing the javac plugin because the inferred sourceroot didn't match the location where Bazel spits out files generated by annotation processors.

By sheer luck, @ciarand in #600 was working through the same issues.

This PR makes the handling of those scenarios more robust and adds a reduced form of the problematic setup to the bazel example, so that it runs on CI

- Handle path with filename separated by `:`
- Detect javac' source generation root
- Not include semanticdb files for auto-generated files

### Test plan

- [x] extra test for source generators in Bazel

I verified that the SCIP index produced contains both examples, and doesn't contain documents for generated code
<img width="540" alt="image" src="https://github.com/sourcegraph/scip-java/assets/1052965/b7989a6a-7f0b-4dea-8140-6d354faa02e6">


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
