### PR TITLE
Add support to auto-index Bazel builds with an aspect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,12 @@ jobs:
       - run: yarn global add @bazel/bazelisk
       - run: sbt cli/pack
       - run: echo "$PWD/scip-java/target/pack/bin" >> $GITHUB_PATH
-      - run: |
+      - name: Auto-index scip-java codebase
+        run: |
+          scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
+      - run: du -h index.scip
+      - name: Auto-index example/bazel-workspace
+        run: |
           scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
         working-directory: examples/bazel-example
       - run: du -h index.scip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
             file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1) 
           }
-          
+
           sudo apt install parallel
           export -f check_repo
 
@@ -72,6 +72,22 @@ jobs:
       - run: bazel build //... --@scip_java//semanticdb-javac:enabled=true
         working-directory: examples/bazel-example
       - run: bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot "$PWD"
+        working-directory: examples/bazel-example
+      - run: du -h index.scip
+        working-directory: examples/bazel-example
+
+  bazel_aspect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn global add @bazel/bazelisk
+      - run: sbt cli/pack
+      - run: echo "$PWD/scip-java/target/pack/bin" >> $GITHUB_PATH
+      - run: |
+          scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
+      - run: du -h index.scip
+      - run: |
+          scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
         working-directory: examples/bazel-example
       - run: du -h index.scip
         working-directory: examples/bazel-example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,76 +5,76 @@ on:
       - main
   pull_request:
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    name: Tests
-    strategy:
-      fail-fast: false
-      matrix:
-        # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
-        # os: [windows-latest, ubuntu-latest]
-        os: [ubuntu-latest]
-        java: [8, 11, 17]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          cache: "sbt"
-          java-version: ${{ matrix.java }}
-      - name: Main project tests
-        run: sbt test
+  # test:
+  #   runs-on: ${{ matrix.os }}
+  #   name: Tests
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
+  #       # os: [windows-latest, ubuntu-latest]
+  #       os: [ubuntu-latest]
+  #       java: [8, 11, 17]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-java@v3
+  #       with:
+  #         distribution: "temurin"
+  #         cache: "sbt"
+  #         java-version: ${{ matrix.java }}
+  #     - name: Main project tests
+  #       run: sbt test
 
-  docker_test:
-    runs-on: ${{ matrix.os }}
-    name: Docker CLI tests
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v2
+  # docker_test:
+  #   runs-on: ${{ matrix.os }}
+  #   name: Docker CLI tests
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          cache: "sbt"
-          java-version: 17
+  #     - uses: actions/setup-java@v3
+  #       with:
+  #         distribution: "temurin"
+  #         cache: "sbt"
+  #         java-version: 17
 
-      - name: Build Dockerised CLI
-        run: sbt cli/docker
+  #     - name: Build Dockerised CLI
+  #       run: sbt cli/docker
 
-      - run: |
+  #     - run: |
 
-          set -eu
-          check_repo() {
-            REPO=$1
-            mkdir -p .repos/$REPO
-            git clone https://github.com/$REPO.git .repos/$REPO
+  #         set -eu
+  #         check_repo() {
+  #           REPO=$1
+  #           mkdir -p .repos/$REPO
+  #           git clone https://github.com/$REPO.git .repos/$REPO
 
-            docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
-            file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1) 
-          }
+  #           docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
+  #           file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1)
+  #         }
 
-          sudo apt install parallel
-          export -f check_repo
+  #         sudo apt install parallel
+  #         export -f check_repo
 
-          parallel -j4 check_repo ::: circe/circe indeedeng/iwf-java-sdk
+  #         parallel -j4 check_repo ::: circe/circe indeedeng/iwf-java-sdk
 
-  bazel:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: yarn global add @bazel/bazelisk
-      - run: bazel build //... --//semanticdb-javac:enabled=true
-      - run: bazel run scip-semanticdb:bazel -- --sourceroot "$PWD"
-      - run: du -h index.scip
-      - run: bazel build //... --@scip_java//semanticdb-javac:enabled=true
-        working-directory: examples/bazel-example
-      - run: bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot "$PWD"
-        working-directory: examples/bazel-example
-      - run: du -h index.scip
-        working-directory: examples/bazel-example
+  # bazel:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - run: yarn global add @bazel/bazelisk
+  #     - run: bazel build //... --//semanticdb-javac:enabled=true
+  #     - run: bazel run scip-semanticdb:bazel -- --sourceroot "$PWD"
+  #     - run: du -h index.scip
+  #     - run: bazel build //... --@scip_java//semanticdb-javac:enabled=true
+  #       working-directory: examples/bazel-example
+  #     - run: bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot "$PWD"
+  #       working-directory: examples/bazel-example
+  #     - run: du -h index.scip
+  #       working-directory: examples/bazel-example
 
   bazel_aspect:
     runs-on: ubuntu-latest
@@ -85,20 +85,17 @@ jobs:
       - run: echo "$PWD/scip-java/target/pack/bin" >> $GITHUB_PATH
       - run: |
           scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
-      - run: du -h index.scip
-      - run: |
-          scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
         working-directory: examples/bazel-example
       - run: du -h index.scip
         working-directory: examples/bazel-example
 
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: 17
-          cache: "sbt"
-      - run: sbt checkAll
+  # check:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: actions/setup-java@v3
+  #       with:
+  #         distribution: "temurin"
+  #         java-version: 17
+  #         cache: "sbt"
+  #     - run: sbt checkAll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,76 +5,76 @@ on:
       - main
   pull_request:
 jobs:
-  # test:
-  #   runs-on: ${{ matrix.os }}
-  #   name: Tests
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
-  #       # os: [windows-latest, ubuntu-latest]
-  #       os: [ubuntu-latest]
-  #       java: [8, 11, 17]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-java@v3
-  #       with:
-  #         distribution: "temurin"
-  #         cache: "sbt"
-  #         java-version: ${{ matrix.java }}
-  #     - name: Main project tests
-  #       run: sbt test
+  test:
+    runs-on: ${{ matrix.os }}
+    name: Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        # NOTE(olafurpg) Windows is not enabled because it times out due to reasons I don't understand.
+        # os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
+        java: [8, 11, 17]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: ${{ matrix.java }}
+      - name: Main project tests
+        run: sbt test
 
-  # docker_test:
-  #   runs-on: ${{ matrix.os }}
-  #   name: Docker CLI tests
-  #   strategy:
-  #     fail-fast: true
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #   steps:
-  #     - uses: actions/checkout@v2
+  docker_test:
+    runs-on: ${{ matrix.os }}
+    name: Docker CLI tests
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - uses: actions/setup-java@v3
-  #       with:
-  #         distribution: "temurin"
-  #         cache: "sbt"
-  #         java-version: 17
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: 17
 
-  #     - name: Build Dockerised CLI
-  #       run: sbt cli/docker
+      - name: Build Dockerised CLI
+        run: sbt cli/docker
 
-  #     - run: |
+      - run: |
 
-  #         set -eu
-  #         check_repo() {
-  #           REPO=$1
-  #           mkdir -p .repos/$REPO
-  #           git clone https://github.com/$REPO.git .repos/$REPO
+          set -eu
+          check_repo() {
+            REPO=$1
+            mkdir -p .repos/$REPO
+            git clone https://github.com/$REPO.git .repos/$REPO
 
-  #           docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
-  #           file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1)
-  #         }
+            docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
+            file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1)
+          }
 
-  #         sudo apt install parallel
-  #         export -f check_repo
+          sudo apt install parallel
+          export -f check_repo
 
-  #         parallel -j4 check_repo ::: circe/circe indeedeng/iwf-java-sdk
+          parallel -j4 check_repo ::: circe/circe indeedeng/iwf-java-sdk
 
-  # bazel:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - run: yarn global add @bazel/bazelisk
-  #     - run: bazel build //... --//semanticdb-javac:enabled=true
-  #     - run: bazel run scip-semanticdb:bazel -- --sourceroot "$PWD"
-  #     - run: du -h index.scip
-  #     - run: bazel build //... --@scip_java//semanticdb-javac:enabled=true
-  #       working-directory: examples/bazel-example
-  #     - run: bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot "$PWD"
-  #       working-directory: examples/bazel-example
-  #     - run: du -h index.scip
-  #       working-directory: examples/bazel-example
+  bazel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn global add @bazel/bazelisk
+      - run: bazel build //... --//semanticdb-javac:enabled=true
+      - run: bazel run scip-semanticdb:bazel -- --sourceroot "$PWD"
+      - run: du -h index.scip
+      - run: bazel build //... --@scip_java//semanticdb-javac:enabled=true
+        working-directory: examples/bazel-example
+      - run: bazel run @scip_java//scip-semanticdb:bazel -- --sourceroot "$PWD"
+        working-directory: examples/bazel-example
+      - run: du -h index.scip
+        working-directory: examples/bazel-example
 
   bazel_aspect:
     runs-on: ubuntu-latest
@@ -89,13 +89,13 @@ jobs:
       - run: du -h index.scip
         working-directory: examples/bazel-example
 
-  # check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-java@v3
-  #       with:
-  #         distribution: "temurin"
-  #         java-version: 17
-  #         cache: "sbt"
-  #     - run: sbt checkAll
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
+          cache: "sbt"
+      - run: sbt checkAll

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ bazel-lsif-java
 VERSION
 
 semanticdb-gradle-plugin/gradle
+aspects/scip_java.bzl

--- a/build.sbt
+++ b/build.sbt
@@ -167,6 +167,10 @@ lazy val javacPlugin = project
             // referenced from META-INF/services/com.sun.source.util.Plugin
             "com.sourcegraph.semanticdb_javac.SemanticdbPlugin" ->
               "com.sourcegraph.semanticdb_javac.SemanticdbPlugin",
+            "com.sourcegraph.semanticdb_javac.PrintJavaVersion" ->
+              "com.sourcegraph.semanticdb_javac.PrintJavaVersion",
+            "com.sourcegraph.semanticdb_javac.InjectSemanticdbOptions" ->
+              "com.sourcegraph.semanticdb_javac.InjectSemanticdbOptions",
             "com.google.**" -> "com.sourcegraph.shaded.com.google.@1",
             // Need to shade the semanticdb-javac compiler plugin in order to be
             // able to index the plugin code itself.
@@ -257,7 +261,7 @@ lazy val cli = project
           }
 
           addJar(
-            (javacPlugin / Compile / assembly).value,
+            (javacPlugin / Compile / Keys.`package`).value,
             "semanticdb-plugin.jar"
           )
           addJar(

--- a/build.sbt
+++ b/build.sbt
@@ -167,13 +167,19 @@ lazy val javacPlugin = project
             // referenced from META-INF/services/com.sun.source.util.Plugin
             "com.sourcegraph.semanticdb_javac.SemanticdbPlugin" ->
               "com.sourcegraph.semanticdb_javac.SemanticdbPlugin",
+            // Don't rename PrintJavaVersion because we load it via FQN to
+            // detect the Java of a JVM installation.
             "com.sourcegraph.semanticdb_javac.PrintJavaVersion" ->
               "com.sourcegraph.semanticdb_javac.PrintJavaVersion",
+            // Don't rename InjectSemanticdbOptions because we load it via FQN to
+            // process a list of Java compiler options.
             "com.sourcegraph.semanticdb_javac.InjectSemanticdbOptions" ->
               "com.sourcegraph.semanticdb_javac.InjectSemanticdbOptions",
             "com.google.**" -> "com.sourcegraph.shaded.com.google.@1",
-            // Need to shade the semanticdb-javac compiler plugin in order to be
-            // able to index the plugin code itself.
+            // Shade everything else in the semanticdb-javac compiler plugin in
+            // order to be able to index the plugin code itself. Without this step,
+            // we can't add the plugin to the classpath while compiling the source
+            // code of the plugin itself because it results in cryptic compile errors.
             "com.sourcegraph.**" -> "com.sourcegraph.shaded.com.sourcegraph.@1",
             "google.**" -> "com.sourcegraph.shaded.google.@1",
             "org.relaxng.**" -> "com.sourcegraph.shaded.relaxng.@1"

--- a/examples/bazel-example/.gitignore
+++ b/examples/bazel-example/.gitignore
@@ -1,2 +1,2 @@
-aspects/scip_java.bzl
 bazel-bazel-example
+aspects/scip_java.bzl

--- a/examples/bazel-example/.gitignore
+++ b/examples/bazel-example/.gitignore
@@ -1,1 +1,2 @@
+aspects/scip_java.bzl
 bazel-bazel-example

--- a/examples/bazel-example/WORKSPACE
+++ b/examples/bazel-example/WORKSPACE
@@ -1,5 +1,6 @@
 # This is an end-to-end example of how to consume scip-java from an external repository.
 workspace(name = "scip_java_example")
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 ##############
@@ -20,11 +21,11 @@ http_archive(
 ##############
 local_repository(
     name = "scip_java",
-    path = "../.."
+    path = "../..",
 )
 
 # Copy and paste this, not the local_repository:
-# 
+#
 # SCIP_JAVA_VERSION="0.8.20"
 # http_archive(
 #   name = "scip_java",
@@ -44,8 +45,11 @@ http_archive(
         "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.20.0.tar.gz",
     ],
 )
+
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()
 
 ##############
@@ -53,27 +57,35 @@ rules_proto_toolchains()
 ##############
 # To update this version, copy-paste instructions from https://github.com/bazelbuild/rules_jvm_external/releases
 RULES_JVM_EXTERNAL_TAG = "4.2"
+
 RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca"
+
 http_archive(
     name = "rules_jvm_external",
-    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     sha256 = RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
+
 load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
 rules_jvm_external_deps()
+
 load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
 rules_jvm_external_setup()
+
 load("@rules_jvm_external//:defs.bzl", "maven_install")
+
 maven_install(
     artifacts = [
-        "com.google.protobuf:protobuf-java:3.15.6", # Required dependency by scip-java.
-        "com.google.protobuf:protobuf-java-util:3.15.6", # Required dependency by scip-java.
+        "com.google.protobuf:protobuf-java:3.15.6",  # Required dependency by scip-java.
+        "com.google.protobuf:protobuf-java-util:3.15.6",  # Required dependency by scip-java.
         # These dependencies are only required for the tests
-        "com.google.guava:guava:31.0-jre", 
+        "com.google.guava:guava:31.0-jre",
         "com.google.auto.value:auto-value:1.5.3",
     ],
     repositories = [
-         "https://repo1.maven.org/maven2",
+        "https://repo1.maven.org/maven2",
     ],
 )

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -79,6 +79,7 @@ def _scip_java(target, ctx):
         "processors": processors,
         "processorpath": processorpath,
         "bootclasspath": bootclasspath,
+        "reportWarningOnEmptyIndex": False,
     })
     build_config_path = ctx.actions.declare_file(ctx.label.name + ".scip.json")
 

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -82,6 +82,8 @@ def _scip_java(target, ctx):
         output = build_config_path,
         content = build_config.to_json(),
     )
+
+    deps = [javac_action.inputs, annotations.processor_classpath]
     ctx.actions.run_shell(
         command = "\"{}\" index --no-cleanup --index-semanticdb.allow-empty-index --cwd \"{}\" --targetroot {} --scip-config \"{}\" --output \"{}\"".format(
             ctx.var["scip_java_binary"],
@@ -94,7 +96,7 @@ def _scip_java(target, ctx):
             "JAVA_HOME": ctx.var["java_home"],
             "NO_PROGRESS_BAR": "true",
         },
-        inputs = [build_config_path],
+        inputs = depset([build_config_path], transitive = deps),
         outputs = [scip_output, targetroot],
     )
 

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -14,6 +14,12 @@ many *.scip (https://github.com/sourcegraph/scip) and
 These files encode information about which symbols are referenced from which
 locations in your source code.
 
+This aspect only works on Linux when using the `local` spawn strategy because
+the `run_shell` action writes SemanticDB and SCIP files to the provided
+--targetroot argument. It should be possible to avoid this requirement
+in the future if there's a strong desire to make the aspect work with the
+default (sandboxed) spawn strategy.
+
 Use the command below to merge all of these SCIP files into a single index:
 
     find bazel-bin/ -type f -name '*.scip' | xargs cat > index.scip
@@ -28,7 +34,7 @@ Use `src code-intel upload` to upload the unified SCIP file to Sourcegraph:
 
 Example command to run this aspect directly:
 
-    bazel build //...  --aspects path/to/scip_java.bzl%scip_java_aspect --output_groups=scip --define=sourceroot=$(pwd) --define=scip_java_binary=$(which scip-java) --define=java_home=$JAVA_HOME
+    bazel build //... --spawn_strategy=local  --aspects path/to/scip_java.bzl%scip_java_aspect --output_groups=scip --define=sourceroot=$(pwd) --define=scip_java_binary=$(which scip-java) --define=java_home=$JAVA_HOME
 
 To learn more about aspects: https://bazel.build/extending/aspects
 """

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -1,0 +1,123 @@
+"""
+Bazel aspect to run scip-java against a Java Bazel codebase.
+
+You can optionally commit this file into your git repository, gitignore it, or
+just delete it. When you run `scip-java index` in a Bazel codebase, this file
+will get re-created and the command will error if the file already exists but with
+different contents.
+
+This aspect is needed for scip-java to inspect the structure of the Bazel build
+and register actions to index all java_library/java_test/java_binary targets.
+The result of running this aspect is that your bazel-bin/ directory will contain
+many *.scip (https://github.com/sourcegraph/scip) and 
+*.semanticdb (https://scalameta.org/docs/semanticdb/specification.html) files.
+These files encode information about which symbols are referenced from which
+locations in your source code.
+
+Use the command below to merge all of these SCIP files into a single index:
+
+    find bazel-bin/ -type f -name '*.scip' | xargs cat > index.scip
+
+Use `src code-intel upload` to upload the unified SCIP file to Sourcegraph:
+
+    npm install -g @sourcegraph/src
+    export SRC_ENDPOINT=SOURCEGRAPH_URL
+    export SRC_ACCESS_TOKEN=TOKEN_VALUE
+    src login # confirm you are correctly authenticated
+    src code-intel upload -file=index.scip
+
+Example command to run this aspect directly:
+
+    bazel build //...  --aspects path/to/scip_java.bzl%scip_java_aspect --output_groups=scip --define=sourceroot=$(pwd) --define=scip_java_binary=$(which scip-java) --define=java_home=$JAVA_HOME
+
+To learn more about aspects: https://bazel.build/extending/aspects
+"""
+
+def _scip_java(target, ctx):
+    if JavaInfo not in target or not hasattr(ctx.rule.attr, "srcs"):
+        return None
+
+    javac_action = None
+    for a in target.actions:
+        if a.mnemonic == "Javac":
+            javac_action = a
+            break
+
+    if not javac_action:
+        return None
+
+    info = target[JavaInfo]
+    compilation = info.compilation_info
+    annotations = info.annotation_processing
+
+    source_files = []
+    for src in ctx.rule.files.srcs:
+        source_files.append(src.path)
+    if len(source_files) == 0:
+        return None
+
+    classpath = [j.path for j in compilation.compilation_classpath.to_list()]
+    bootclasspath = [j.path for j in compilation.boot_classpath]
+
+    processorpath = []
+    processors = []
+    if annotations and annotations.enabled:
+        processorpath += [j.path for j in annotations.processor_classpath.to_list()]
+        processors = annotations.processor_classnames
+
+    build_config = struct(**{
+        "javaHome": ctx.var["java_home"],
+        "classpath": classpath,
+        "sourceFiles": source_files,
+        "javacOptions": compilation.javac_options,
+        "processors": processors,
+        "processorpath": processorpath,
+        "bootclasspath": bootclasspath,
+    })
+    build_config_path = ctx.actions.declare_file(ctx.label.name + ".scip.json")
+
+    scip_output = ctx.actions.declare_file(ctx.label.name + ".scip")
+    targetroot = ctx.actions.declare_directory(ctx.label.name + ".semanticdb")
+    ctx.actions.write(
+        output = build_config_path,
+        content = build_config.to_json(),
+    )
+    ctx.actions.run_shell(
+        command = "\"{}\" index --no-cleanup --index-semanticdb.allow-empty-index --cwd \"{}\" --targetroot {} --scip-config \"{}\" --output \"{}\"".format(
+            ctx.var["scip_java_binary"],
+            ctx.var["sourceroot"],
+            targetroot.path,
+            build_config_path.path,
+            scip_output.path,
+        ),
+        env = {
+            "JAVA_HOME": ctx.var["java_home"],
+            "NO_PROGRESS_BAR": "true",
+        },
+        inputs = [build_config_path],
+        outputs = [scip_output, targetroot],
+    )
+
+    return scip_output
+
+def _scip_java_aspect(target, ctx):
+    scip = _scip_java(target, ctx)
+    if not scip:
+        return struct()
+    return [OutputGroupInfo(scip = [scip])]
+
+scip_java_aspect = aspect(
+    _scip_java_aspect,
+)
+
+def _scip_java_impl(ctx):
+    output = ctx.attr.compilation[OutputGroupInfo]
+    return [
+        OutputGroupInfo(scip = output.scip),
+        DefaultInfo(files = output.scip),
+    ]
+
+scip_java = rule(
+    implementation = _scip_java_impl,
+    attrs = {"compilation": attr.label(aspects = [scip_java_aspect])},
+)

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/Embedded.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/Embedded.scala
@@ -112,6 +112,14 @@ object Embedded {
     }
   }
 
+  def bazelAspectFile(tmpDir: Path): String = {
+    val tmpFile = copyFile(tmpDir, "scip-java/scip_java.bzl")
+    val contents =
+      new String(Files.readAllBytes(tmpFile), StandardCharsets.UTF_8)
+    Files.deleteIfExists(tmpFile)
+    contents
+  }
+
   private def copyFile(tmpDir: Path, filename: String): Path = {
     val in = this.getClass.getResourceAsStream(s"/$filename")
     val out = tmpDir.resolve(filename)

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/Embedded.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/Embedded.scala
@@ -112,7 +112,12 @@ object Embedded {
     }
   }
 
+  /**
+   * Returns the string contents of the scip_java.bzl file on disk.
+   */
   def bazelAspectFile(tmpDir: Path): String = {
+    // We could in theory load the resource straight into a string but it was
+    // easier to copy it to a file and read it from there.
     val tmpFile = copyFile(tmpDir, "scip-java/scip_java.bzl")
     val contents =
       new String(Files.readAllBytes(tmpFile), StandardCharsets.UTF_8)

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
@@ -32,7 +32,10 @@ class BazelBuildTool(index: IndexCommand) extends BuildTool("Bazel", index) {
         buildCommand += "bazel"
         buildCommand += "build"
         buildCommand += "--noshow_progress"
-        buildCommand += "--sandbox_debug"
+
+        // The local strategy is required for now because we write SemanticDB and SCIP files
+        // to the provided targetroot directory.
+        buildCommand += "--spawn_strategy=local"
 
         val targetSpecs = ListBuffer.empty[String]
         if (index.buildCommand.isEmpty) {

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
@@ -8,7 +8,9 @@ import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.BasicFileAttributes
+
 import scala.collection.mutable.ListBuffer
+
 import com.sourcegraph.io.AbsolutePath
 import com.sourcegraph.scip_java.Embedded
 import com.sourcegraph.scip_java.commands.IndexCommand

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
@@ -136,8 +136,8 @@ class BazelBuildTool(index: IndexCommand) extends BuildTool("Bazel", index) {
         .app
         .error(
           s"doing nothing, the directory $bazelOut does not exist. " +
-            s"The most likely cause for this problem is that there are no Java targets in this Bazel workspace. " +
-            s"Please report an issue to the scip-java issue tracker if the command `bazel query 'kind(java_*, //...)'` returns non-empty output."
+            "The most likely cause for this problem is that there are no Java targets in this Bazel workspace. " +
+            "Please report an issue to the scip-java issue tracker if the command `bazel query 'kind(java_*, //...)'` returns non-empty output."
         )
     } else {
       val bazelOutLink = Files.readSymbolicLink(bazelOut)

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BazelBuildTool.scala
@@ -1,7 +1,18 @@
 package com.sourcegraph.scip_java.buildtools
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardOpenOption
+import java.nio.file.attribute.BasicFileAttributes
 
+import scala.collection.mutable.ListBuffer
+
+import com.sourcegraph.io.AbsolutePath
+import com.sourcegraph.scip_java.Embedded
 import com.sourcegraph.scip_java.commands.IndexCommand
 
 class BazelBuildTool(index: IndexCommand) extends BuildTool("Bazel", index) {
@@ -13,15 +24,161 @@ class BazelBuildTool(index: IndexCommand) extends BuildTool("Bazel", index) {
   }
 
   override def generateScip(): Int = {
-    index
-      .app
-      .reporter
-      .error(
-        "The `scip-java index` command does not work with Bazel builds because Bazel " +
-          "requires custom configuration to be added to WORKSPACE and BUILD files. " +
-          "The scip-java repository contains an example WORKSPACE file to demonstrate " +
-          "how to use scip-java with Bazel https://github.com/sourcegraph/scip-java/blob/main/examples/bazel-example/WORKSPACE"
-      )
-    1
+    this.generateAspectFile() match {
+      case None =>
+        1
+      case Some(aspectLabel) =>
+        val buildCommand = ListBuffer.empty[String]
+        buildCommand += "bazel"
+        buildCommand += "build"
+
+        val targetSpecs = ListBuffer.empty[String]
+        if (index.buildCommand.isEmpty) {
+          targetSpecs += "//..."
+        } else {
+          targetSpecs ++= index.buildCommand
+        }
+        buildCommand ++= targetSpecs
+
+        buildCommand += "--aspects"
+        buildCommand += s"$aspectLabel%scip_java_aspect"
+        buildCommand += "--output_groups=scip"
+        buildCommand += s"--define=sourceroot=${index.workingDirectory}"
+
+        val javaHome = index
+          .app
+          .env
+          .environmentVariables
+          .getOrElse("JAVA_HOME", "")
+        if (javaHome.isEmpty) {
+          index
+            .app
+            .error(
+              "environment variable JAVA_HOME is not set. " +
+                "To fix this problem run `export JAVA_HOME=/path/to/java` and run scip-java index again."
+            )
+          return 1
+        }
+        buildCommand += s"--define=java_home=$javaHome"
+
+        val scipJavaBinary = index.bazelScipJavaBinary.getOrElse("")
+        if (scipJavaBinary.isEmpty) {
+          index
+            .app
+            .error(
+              "the flag --bazel-scip-java-binary is required to index Bazel codebases. To fix this problem, run scip-java index again with the flag --scip-java-binary=/path/to/scip-java"
+            )
+          return 1
+        }
+        buildCommand += s"--define=scip_java_binary=$scipJavaBinary"
+
+        index.app.info(buildCommand.mkString(" "))
+        val commandResult = index
+          .app
+          .process(buildCommand.toList)
+          .call(check = false)
+        if (commandResult.exitCode != 0) {
+          index
+            .app
+            .error(
+              s"""To reproduce the failed Bazel command without scip-java, run the following command:
+                 |
+                 |  bazel build ${targetSpecs.mkString(" ")}
+                 |
+                 |To narrow the set of targets to index or pass additional flags to Bazel, include extra arguments index after -- like below:
+                 |
+                 |  scip-java index --bazel-scip-java-binary=... -- //custom/target --sandbox_debug
+                 |""".stripMargin
+            )
+          return commandResult.exitCode
+        }
+        // Final step after running the aspect: aggregate all the generated `*.scip` files into a single index.scip file.
+        // We have to do this step outside of Bazel because Bazel does not allow actions to generate outputs outside
+        // of the bazel-out directory. Ideally, we should be able to implement the aggregation step inside Bazel
+        // and only copy the resulting index.scip file into the root of the workspace. However, to begin with, we
+        // walk the bazel-bin/ directory to concatenate the `*.scip` files even if this is not the idiomatic way to
+        // do it (in general, scanning the bazel-bin/ directory is a big no no).
+        Files.deleteIfExists(index.finalOutput)
+        Files.createDirectories(index.finalOutput.getParent)
+        val scipPattern = FileSystems.getDefault.getPathMatcher("glob:**.scip")
+        val binDirectory = Files
+          .readSymbolicLink(index.workingDirectory.resolve("bazel-bin"))
+        Files.walkFileTree(
+          binDirectory,
+          new SimpleFileVisitor[Path] {
+            override def visitFile(
+                file: Path,
+                attrs: BasicFileAttributes
+            ): FileVisitResult = {
+              if (scipPattern.matches(file)) {
+                val bytes = Files.readAllBytes(file)
+                Files.write(
+                  index.finalOutput,
+                  bytes,
+                  StandardOpenOption.APPEND,
+                  StandardOpenOption.CREATE
+                )
+              }
+              super.visitFile(file, attrs)
+            }
+          }
+        )
+        0
+    }
+  }
+
+  /**
+   * Reads the scip_java.bzl file from resources and writes it to the
+   * aspect/scip_java.bzl file inside the Bazel workspace.
+   */
+  private def generateAspectFile(): Option[String] = {
+    val aspectPath = AbsolutePath.of(index.bazelAspect, index.workingDirectory)
+    val aspectContents =
+      TemporaryFiles.withDirectory(index) { tmp =>
+        Embedded.bazelAspectFile(tmp)
+      }
+    if (index.bazelOverwriteAspectFile || !Files.exists(aspectPath)) {
+      Files.deleteIfExists(aspectPath)
+      Files.createDirectories(aspectPath.getParent)
+      Files.write(aspectPath, aspectContents.getBytes(StandardCharsets.UTF_8))
+    } else if (Files.isRegularFile(aspectPath)) {
+      val existingContents = new String(Files.readAllBytes(aspectPath))
+      if (existingContents != aspectContents) {
+        index
+          .app
+          .reporter
+          .error(
+            s"Outdated Bazel aspect file found at $aspectPath. To fix this problem, either run again with the flag --bazel-overwrite-aspect-file or update the contents of the file to the following:\n\n$aspectContents\n\n"
+          )
+        return None
+      }
+    } else if (Files.exists(aspectPath)) {
+      index
+        .app
+        .reporter
+        .error(
+          "path $aspectPath already exists and is not a file. To fix this problem, remove this path and try again."
+        )
+      return None
+    }
+
+    Some(aspectLabel(aspectPath))
+  }
+
+  /**
+   * Returns the target name (aka. "label") to reference the given path.
+   */
+  private def aspectLabel(aspectPath: Path): String = {
+    var parent = aspectPath.getParent
+    while (parent.startsWith(index.workingDirectory)) {
+      if (Files.isRegularFile(parent.resolve("BUILD"))) {
+        val path = index.workingDirectory.relativize(parent)
+        val name = parent.relativize(aspectPath)
+        return s"//$path:$name"
+      }
+      parent = parent.getParent
+    }
+    Files.createFile(aspectPath.resolveSibling("BUILD"))
+    index.workingDirectory.relativize(aspectPath).toString
   }
 }

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/BuildTool.scala
@@ -4,7 +4,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 import com.sourcegraph.scip_java.commands.IndexCommand
-import com.sourcegraph.scip_java.commands.IndexSemanticdbCommand
 import os.CommandResult
 
 /**
@@ -56,13 +55,16 @@ object BuildTool {
     } else if (generateSemanticdbResult.exitCode != 0) {
       generateSemanticdbResult.exitCode
     } else {
-      IndexSemanticdbCommand(
-        output = index.finalOutput,
-        targetroot = List(targetroot),
-        packagehub = index.packagehub,
-        buildKind = buildKind,
-        app = index.app
-      ).run()
+      index
+        .indexSemanticdb
+        .copy(
+          output = index.finalOutput,
+          targetroot = List(targetroot),
+          packagehub = index.packagehub,
+          buildKind = buildKind,
+          app = index.app
+        )
+        .run()
     }
   }
 }

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
@@ -424,7 +424,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
       .iterator()
     if (compilers.hasNext) {
       val classpath = deps.classpath ++ scalaLibrary
-      val argsfile = tmp.resolve("javacopts.txt")
+      val argsfile = targetroot.resolve("javacopts.txt")
       Files.createDirectories(argsfile.getParent)
       Files.write(
         argsfile,
@@ -492,7 +492,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
           AbsolutePath.of(Paths.get(path), index.workingDirectory).toString
         )
     actualClasspath ++= deps.classpath.map(_.toString)
-    val argsfile = tmp.resolve("javacopts.txt")
+    val argsfile = targetroot.resolve("javacopts.txt")
     val arguments = ListBuffer.empty[String]
     arguments += "-encoding"
     arguments += "utf8"

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
@@ -20,6 +20,7 @@ import java.util.ServiceLoader
 import java.util.concurrent.TimeUnit
 import java.util.jar.JarFile
 
+import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
@@ -31,6 +32,7 @@ import scala.util.control.NonFatal
 import scala.meta.pc.PresentationCompiler
 import scala.meta.pc.PresentationCompilerConfig
 
+import com.sourcegraph.io.AbsolutePath
 import com.sourcegraph.io.DeleteVisitor
 import com.sourcegraph.scip_java.BuildInfo
 import com.sourcegraph.scip_java.Dependencies
@@ -92,7 +94,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
   private val moduleInfo = Paths.get("module-info.java")
 
   override def usedInCurrentDirectory(): Boolean =
-    Files.isRegularFile(configFile)
+    configFiles.exists(path => Files.isRegularFile(path))
   override def isHidden: Boolean = true
   override def generateScip(): Int = {
     BuildTool.generateScipFromTargetroot(
@@ -105,8 +107,11 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
 
   private def targetroot: Path = index.finalTargetroot(defaultTargetroot)
   private def defaultTargetroot: Path = Paths.get("target")
-  private def configFile =
-    index.workingDirectory.resolve(ScipBuildTool.ConfigFileName)
+  private def configFiles =
+    index.scipConfig.toList ++
+      ScipBuildTool
+        .ConfigFileNames
+        .map(name => index.workingDirectory.resolve(name))
   private def buildKind: String = parsedConfig.fold(_.kind, _ => "")
   private def generateSemanticdb(): CommandResult = {
     parsedConfig match {
@@ -133,12 +138,23 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
 
   /** Parses the lsif-java.json file into a Config object. */
   private def parsedConfig: Result[Config] = {
-    val input = Input.path(configFile)
-    JsonParser
-      .parse(input)
-      .flatMap(json =>
-        Config.codec.decode(DecodingContext(json).withFatalUnknownFields(true))
-      )
+    configFiles.find(path => Files.isRegularFile(path)) match {
+      case None =>
+        ErrorResult(
+          Diagnostic.error(
+            s"no config file found. To fix this problem, create a config file in the path '${configFiles.head}'"
+          )
+        )
+      case Some(configFile) =>
+        val input = Input.path(configFile)
+        JsonParser
+          .parse(input)
+          .flatMap(json =>
+            Config
+              .codec
+              .decode(DecodingContext(json).withFatalUnknownFields(true))
+          )
+    }
   }
 
   /**
@@ -154,16 +170,17 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
     if (!Files.isDirectory(sourceroot)) {
       throw new NoSuchFileException(sourceroot.toString)
     }
-    val allSourceFiles = collectAllSourceFiles(sourceroot)
+    val allSourceFiles = collectAllSourceFiles(config, sourceroot)
     val javaFiles = allSourceFiles.filter(javaPattern.matches)
     val scalaFiles = allSourceFiles.filter(scalaPattern.matches)
     val kotlinFiles = allSourceFiles.filter(kotlinPattern.matches)
     if (javaFiles.isEmpty && scalaFiles.isEmpty && kotlinFiles.isEmpty) {
-      index
-        .app
-        .warning(
-          s"doing nothing, no files matching pattern '$sourceroot/**.{java,scala,kt}'"
-        )
+      if (config.sourceFiles.isEmpty)
+        index
+          .app
+          .warning(
+            s"doing nothing, no files matching pattern '$sourceroot/**.{java,scala,kt}'"
+          )
       return CommandResult(0, Nil)
     }
 
@@ -208,7 +225,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
       config: Config,
       allKotlinFiles: List[Path]
   ): Try[Unit] = {
-    if (allKotlinFiles.isEmpty)
+    if (allKotlinFiles.isEmpty || config.dependencies.isEmpty)
       return Success()
     val filesPaths = allKotlinFiles.map(_.toString)
 
@@ -333,7 +350,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
       allScalaFiles: List[Path]
   ): Try[Unit] =
     Try {
-      if (allScalaFiles.nonEmpty)
+      if (deps.dependencies.nonEmpty && allScalaFiles.nonEmpty)
         withScalaPresentationCompiler(deps) { compiler =>
           allScalaFiles.foreach { path =>
             try compileScalaFile(compiler, path)
@@ -465,8 +482,15 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
     if (javaFiles.isEmpty)
       return Success(())
     val semanticdbJar = Embedded.semanticdbJar(tmp)
-    val coursier = Embedded.coursier(tmp)
-    val actualClasspath = deps.classpath :+ semanticdbJar
+    val actualClasspath = ArrayBuffer.empty[String]
+    actualClasspath += semanticdbJar.toString
+    actualClasspath ++=
+      config
+        .classpath
+        .map(path =>
+          AbsolutePath.of(Paths.get(path), index.workingDirectory).toString
+        )
+    actualClasspath ++= deps.classpath.map(_.toString)
     val argsfile = targetroot.resolve("javacopts.txt")
     val arguments = ListBuffer.empty[String]
     arguments += "-encoding"
@@ -478,10 +502,41 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
     arguments += generatedDir(tmp, "s")
     arguments += "-h"
     arguments += generatedDir(tmp, "h")
-    arguments += "-classpath"
-    arguments += actualClasspath.mkString(File.pathSeparator)
+    if (actualClasspath.nonEmpty) {
+      arguments += "-classpath"
+      arguments += actualClasspath.mkString(File.pathSeparator)
+    }
     arguments +=
       s"-Xplugin:semanticdb -targetroot:$targetroot -sourceroot:$sourceroot"
+    if (config.processorpath.nonEmpty) {
+      arguments += "-processorpath"
+      val processorpath =
+        semanticdbJar.toString ::
+          config
+            .processorpath
+            .flatMap(path => guessBazelJar(path, index.workingDirectory))
+            .map(_.toString)
+      arguments += processorpath.mkString(File.pathSeparator)
+    }
+    val isIgnoredAnnotationProcessor =
+      ScipBuildTool.isIgnoredAnnotationProcessor ++
+        index.scipIgnoredAnnotationProcessors
+    val processors = config.processors.filterNot(isIgnoredAnnotationProcessor)
+    if (processors.nonEmpty) {
+      arguments += "-processor"
+      arguments += processors.mkString(",")
+    }
+    arguments ++=
+      config
+        .javacOptions
+        .filterNot(option =>
+          option.startsWith("-Xep") ||
+            option
+              .startsWith("-Xplugin:semanticdb") || option.startsWith("-XD") ||
+            index
+              .scipIgnoredJavacOptionPrefixes
+              .exists(prefix => option.startsWith(prefix))
+        )
     if (config.kind == "jdk" && moduleInfos.nonEmpty) {
       moduleInfos.foreach { module =>
         arguments += "--module"
@@ -500,21 +555,7 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
     val pipe = Readlines(line => {
       index.app.reporter.info(line)
     })
-    val javac = Paths.get(
-      os.proc(
-          coursier.toString,
-          "java-home",
-          "--jvm",
-          config.jvm,
-          "--architecture",
-          jvmArchitecture
-        )
-        .call()
-        .out
-        .trim(),
-      "bin",
-      "javac"
-    )
+    val javac = javacPath(config, tmp)
     index.app.reporter.info(s"$$ $javac @$argsfile")
     val javacModuleOptions: Seq[String] =
       if (config.jvm != "8")
@@ -535,6 +576,35 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
       Failure(SubprocessException(result))
   }
 
+  private def javacPath(config: Config, tmp: Path): Path = {
+    config.javaHome match {
+      case Some(home) =>
+        Paths.get(home, "bin", "javac")
+      case None =>
+        javacPathViaCoursier(config.jvm, tmp)
+    }
+  }
+
+  private def javacPathViaCoursier(jvmVersion: String, tmp: Path): Path = {
+    val coursier = Embedded.coursier(tmp)
+    Paths.get(
+      os.proc(
+          coursier.toString,
+          "java-home",
+          "--jvm",
+          jvmVersion,
+          "--architecture",
+          jvmArchitecture
+        )
+        .call()
+        .out
+        .trim(),
+      "bin",
+      "javac"
+    )
+
+  }
+
   private def jvmArchitecture: String =
     if (scala.util.Properties.isMac && sys.props("os.arch") == "aarch64")
       "amd64"
@@ -553,7 +623,13 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
   }
 
   /** Recursively collects all Java files in the working directory */
-  private def collectAllSourceFiles(dir: Path): List[Path] = {
+  private def collectAllSourceFiles(config: Config, dir: Path): List[Path] = {
+    if (config.sourceFiles.nonEmpty) {
+      return config
+        .sourceFiles
+        .map(path => AbsolutePath.of(Paths.get(path), dir))
+        .filter(path => Files.isRegularFile(path))
+    }
     val buf = ListBuffer.empty[Path]
     Files.walkFileTree(
       dir,
@@ -583,6 +659,41 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
       }
     )
     buf.toList
+  }
+
+  // HACK(olafurpg): I haven't figured out a reliable way to get annotation processor jars on the processorpath.
+  // The Bazel aspect sometimes says a NAME.jar file is on the processorpath when it doesn't exist but processed_NAME.jar or header_NAME.jar exists.
+  // The long-term solution is figuring out how to get the exact same processorpath as Bazel uses for compilation.
+  private def guessBazelJar(
+      pathString: String,
+      workingDirectory: Path
+  ): Option[Path] = {
+    var path = AbsolutePath.of(Paths.get(pathString), workingDirectory)
+    if (Files.isRegularFile(path))
+      return Some(path)
+
+    // In some cases, the bazel-out/ prefix is missing from the path that Bazel gives us.
+    if (
+      !pathString.startsWith("bazel-bin") && !pathString.startsWith("bazel-out")
+    ) {
+      path = AbsolutePath
+        .of(Paths.get("bazel-out", pathString), workingDirectory)
+
+      if (Files.isRegularFile(path))
+        return Some(path)
+    }
+
+    val processed = path
+      .resolveSibling("processed_" + path.getFileName.toString)
+    if (Files.isRegularFile(processed))
+      return Some(processed)
+
+    val header = path.resolveSibling("header_" + path.getFileName.toString)
+    if (Files.isRegularFile(header))
+      return Some(header)
+
+    index.app.warning("annotation processor jar does not exist: " + path)
+    None
   }
 
   private def generatedDir(tmp: Path, name: String): String = {
@@ -639,7 +750,14 @@ class ScipBuildTool(index: IndexCommand) extends BuildTool("SCIP", index) {
 
   /** Gets parsed from lsif-java.json files. */
   private case class Config(
+      javaHome: Option[String] = None,
       dependencies: List[Dependency] = Nil,
+      sourceFiles: List[String] = Nil,
+      classpath: List[String] = Nil,
+      bootclasspath: List[String] = Nil,
+      processorpath: List[String] = Nil,
+      processors: List[String] = Nil,
+      javacOptions: List[String] = Nil,
       jvm: String = "8",
       kind: String = ""
   )
@@ -657,5 +775,9 @@ object ScipBuildTool {
   // canonical URLs will become 404 links. The lsif-java.json file is not
   // supposed to be written by end-users anyways. It's mostly an implementation
   // default for how we support cross-repo navigation with scip-java.
-  val ConfigFileName = "lsif-java.json"
+  val ConfigFileNames = List("scip-java.json", "lsif-java.json")
+  val isIgnoredAnnotationProcessor = Set(
+    "",
+    "org.openjdk.jmh.generators.BenchmarkProcessor"
+  )
 }

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexCommand.scala
@@ -76,6 +76,9 @@ case class IndexCommand(
       "If true, overwrites the existing Bazel aspect file (if any)"
     ) bazelOverwriteAspectFile: Boolean = false,
     @Description(
+      "If true, automatically tries to extract the printed out sandbox command and re-run the command to reveal the underlying problem."
+    ) bazelAutorunSandboxCommand: Boolean = true,
+    @Description(
       "Optional. The build command to use to compile all sources. " +
         "Defaults to a build-specific command. For example, the default command for Maven command is 'clean verify -DskipTests'." +
         "To override the default, pass in the build command after a double dash: 'scip-java index -- compile test:compile'"

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexCommand.scala
@@ -6,6 +6,7 @@ import java.nio.file.Paths
 
 import com.sourcegraph.io.AbsolutePath
 import com.sourcegraph.scip_java.buildtools.BuildTool
+import com.sourcegraph.scip_java.buildtools.ScipBuildTool
 import fansi.Color
 import moped.annotations._
 import moped.cli.Application
@@ -52,12 +53,36 @@ case class IndexCommand(
     packagehub: Option[String] = None,
     @Hidden // Hidden because it's only used for testing purposes
     temporaryDirectory: Option[Path] = None,
+    @Section("SCIP Build Tool")
+    @Description(
+      "List of Java compiler option prefixes that should be excluded from compilation during indexing. " +
+        "This flag is only used when indexing via scip-java.json files or Bazel."
+    ) scipIgnoredJavacOptionPrefixes: List[String] = Nil,
+    @Description(
+      "List of fully qualified annotation processors that should be ignored when indexing a codebase. " +
+        "This flag is only used when indexing via scip-java.json files or Bazel."
+    ) scipIgnoredAnnotationProcessors: List[String] = Nil,
+    @Description(
+      "Path to a scip-java.json file with build configuration. By default, the path scip-java.json is used."
+    ) scipConfig: Option[Path] = None,
+    @Section("Bazel")
+    @Description(
+      "Optional path to a `scip-java` binary. Required to index a Bazel codebase."
+    ) bazelScipJavaBinary: Option[String] = None,
+    @Description(
+      "Relative path to a Bazel aspect file with an aspect named 'scip_java_aspect'."
+    ) bazelAspect: Path = Paths.get("aspects/scip_java.bzl"),
+    @Description(
+      "If true, overwrites the existing Bazel aspect file (if any)"
+    ) bazelOverwriteAspectFile: Boolean = false,
     @Description(
       "Optional. The build command to use to compile all sources. " +
         "Defaults to a build-specific command. For example, the default command for Maven command is 'clean verify -DskipTests'." +
         "To override the default, pass in the build command after a double dash: 'scip-java index -- compile test:compile'"
     )
     @TrailingArguments() buildCommand: List[String] = Nil,
+    @Hidden
+    indexSemanticdb: IndexSemanticdbCommand = IndexSemanticdbCommand(),
     @Inline
     app: Application = Application.default
 ) extends Command {
@@ -129,13 +154,17 @@ case class IndexCommand(
             unknownBuildTool(buildTool, usedBuildTools)
           case tool :: Nil =>
             tool.generateScip()
-          case many =>
-            val names = many.map(_.name).mkString(", ")
-            app.error(
-              s"Multiple build tools detected: $names. " +
-                s"To fix this problem, use the '--build-tool=BUILD_TOOL_NAME' flag to specify which build tool to run."
-            )
-            1
+          case many @ (first :: rest) =>
+            if (first.isInstanceOf[ScipBuildTool] && scipConfig.isDefined) {
+              first.generateScip()
+            } else {
+              val names = many.map(_.name).mkString(", ")
+              app.error(
+                s"Multiple build tools detected: $names. " +
+                  s"To fix this problem, use the '--build-tool=BUILD_TOOL_NAME' flag to specify which build tool to run."
+              )
+              1
+            }
         }
     }
   }

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexSemanticdbCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexSemanticdbCommand.scala
@@ -48,6 +48,10 @@ final case class IndexSemanticdbCommand(
     @Description(
       "The kind of this build, one of: empty string, jdk, maven"
     ) buildKind: String = "",
+    @Description(
+      "If true, don't report an error when no documents have been indexed. " +
+        "The resulting SCIP index will silently be empty instead."
+    ) allowEmptyIndex: Boolean = false,
     @Inline() app: Application = Application.default
 ) extends Command {
   def sourceroot: Path = AbsolutePath.of(app.env.workingDirectory)
@@ -90,7 +94,8 @@ final case class IndexSemanticdbCommand(
         parallel,
         packages.map(_.toPackageInformation).asJava,
         buildKind,
-        emitInverseRelationships
+        emitInverseRelationships,
+        allowEmptyIndex
       )
     ScipSemanticdb.run(options)
     postPackages(packages)

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/BazelBuildTool.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/BazelBuildTool.java
@@ -63,9 +63,9 @@ public class BazelBuildTool {
             ScipOutputFormat.TYPED_PROTOBUF,
             options.parallel,
             mavenPackages,
-            "",
-            true,
-            true);
+            /* buildKind */ "",
+            /* emitInverseRelationships */ true,
+            /* allowEmptyIndex */ true);
     ScipSemanticdb.run(scipOptions);
 
     if (!scipOptions.reporter.hasErrors()) {
@@ -109,7 +109,7 @@ public class BazelBuildTool {
               String[] parts = tag.substring("maven_coordinates=".length()).split(":");
               if (parts.length == 3) {
                 // The jar part is populated via `withJar()` below.
-                basePackage = new MavenPackage(/* jar = */ null, parts[0], parts[1], parts[2]);
+                basePackage = new MavenPackage(/* jar= */ null, parts[0], parts[1], parts[2]);
               }
             }
           }

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/BazelBuildTool.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/BazelBuildTool.java
@@ -64,6 +64,7 @@ public class BazelBuildTool {
             options.parallel,
             mavenPackages,
             "",
+            true,
             true);
     ScipSemanticdb.run(scipOptions);
 

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/MessageOnlyException.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/MessageOnlyException.java
@@ -1,0 +1,12 @@
+package com.sourcegraph.scip_semanticdb;
+
+public class MessageOnlyException extends Throwable {
+  public MessageOnlyException(String message) {
+    super(message);
+  }
+
+  @Override
+  public synchronized Throwable fillInStackTrace() {
+    return this;
+  }
+}

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/MessageOnlyException.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/MessageOnlyException.java
@@ -1,5 +1,10 @@
 package com.sourcegraph.scip_semanticdb;
 
+/**
+ * Exception that doesn't fill out the stack trace, it only prints out the message.
+ *
+ * <p>Use this exception if you want prettier console output without stack trace noise.
+ */
 public class MessageOnlyException extends Throwable {
   public MessageOnlyException(String message) {
     super(message);

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
@@ -43,7 +43,7 @@ public class ScipSemanticdb {
     List<Path> files = SemanticdbWalker.findSemanticdbFiles(options);
     Collections.sort(files);
     if (options.reporter.hasErrors()) return;
-    if (files.isEmpty()) {
+    if (files.isEmpty() && !options.allowEmptyIndex) {
       options.reporter.error(
           "No SemanticDB files found. "
               + "This typically means that `scip-java` is unable to automatically "

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdbOptions.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdbOptions.java
@@ -18,6 +18,7 @@ public class ScipSemanticdbOptions {
   public final List<MavenPackage> packages;
   public final String buildKind;
   public final boolean emitInverseRelationships;
+  public final boolean allowEmptyIndex;
 
   public ScipSemanticdbOptions(
       List<Path> targetroots,
@@ -30,7 +31,8 @@ public class ScipSemanticdbOptions {
       boolean parallel,
       List<MavenPackage> packages,
       String buildKind,
-      boolean emitInverseRelationships) {
+      boolean emitInverseRelationships,
+      boolean allowEmptyIndex) {
     this.targetroots = targetroots;
     this.output = output;
     this.sourceroot = sourceroot;
@@ -42,5 +44,6 @@ public class ScipSemanticdbOptions {
     this.packages = packages;
     this.buildKind = buildKind;
     this.emitInverseRelationships = emitInverseRelationships;
+    this.allowEmptyIndex = allowEmptyIndex;
   }
 }

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdbReporter.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdbReporter.java
@@ -10,7 +10,7 @@ public abstract class ScipSemanticdbReporter {
   public void error(Throwable e) {}
 
   public void error(String message) {
-    error(new RuntimeException(message));
+    error(new MessageOnlyException(message));
   }
 
   public void startProcessing(int taskSize) {}


### PR DESCRIPTION
Previously, the Bazel example required monkeypatching the `java_library` rule in order to inject the SemanticDB compiler plugin. This PR is an exploration to replace monkeypatching with aspects, which is a Bazel feature that seems made for our exact use-case. The goal of this PR is to make it possible to auto-index Bazel codebases with as little changes as possible to the existing build configuration in WORKSPACE and BUILD files.


With this change, it should be possible to index most Java/Bazel codebases with the following command
```
scip-java index --bazel-scip-java-binary=$(which scip-java)
```

### Test plan

- See new `bazel_aspect` CI job that indexes scip-java itself and the example workspace
- Green CI.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
