### PR TITLE
Add `-no-relative-path:` flag to control indexing of generated files

### DIFF
--- a/semanticdb-javac/defs.bzl
+++ b/semanticdb-javac/defs.bzl
@@ -1,18 +1,20 @@
 """Java rules that automatically register the SemanticDB compiler plugin based on the presence of a string flag."""
-load("@rules_java//java:defs.bzl", native_java_library="java_library", native_java_binary="java_binary")
 
-def java_library(javacopts=[], plugins=[],**kwargs):
+load("@rules_java//java:defs.bzl", native_java_binary = "java_binary", native_java_library = "java_library")
+
+def java_library(javacopts = [], plugins = [], **kwargs):
     native_java_library(
-	    javacopts=_actual_javacopts(javacopts),
-	    plugins=_actual_plugins(plugins),
-	    **kwargs)
+        javacopts = _actual_javacopts(javacopts),
+        plugins = _actual_plugins(plugins),
+        **kwargs
+    )
 
-
-def java_binary(javacopts=[], plugins=[],**kwargs):
+def java_binary(javacopts = [], plugins = [], **kwargs):
     native_java_binary(
-	    javacopts=_actual_javacopts(javacopts),
-	    plugins=_actual_plugins(plugins),
-	    **kwargs)
+        javacopts = _actual_javacopts(javacopts),
+        plugins = _actual_plugins(plugins),
+        **kwargs
+    )
 
 def _actual_javacopts(javacopts):
     return select({

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/NoRelativePathMode.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/NoRelativePathMode.java
@@ -1,0 +1,28 @@
+package com.sourcegraph.semanticdb_javac;
+
+/**
+ * Configuration options to determine how semanticdb-javac should handle files that have no good
+ * relative paths.
+ *
+ * <p>When indexing a file at an absolute path /project/src/main/example/Foo.java, SemanticDB needs
+ * to know the "sourceroot" path /project in order to relativize the path of the source file into
+ * src/main/example/Foo.java. This configuration option determines what the compiler plugin should
+ * do when it's not able to find a good relative path.
+ */
+public enum NoRelativePathMode {
+
+  /**
+   * Come up with a unique relative path for the SemanticDB path with no guarantee that this path
+   * corresponds to the original path of the generated source file.
+   */
+  INDEX_ANYWAY,
+
+  /** Silently ignore the file, don't index it. */
+  SKIP,
+
+  /** Report an error message and fail the compilation. */
+  ERROR,
+
+  /** Ignore the file, but print a message explaining it's ignored. */
+  WARNING
+}

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -436,15 +436,22 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
 
   private String semanticdbUri() {
     Path absolutePath = SemanticdbTaskListener.absolutePathFromUri(options, event.getSourceFile());
-    Path relativePath = options.sourceroot.relativize(absolutePath);
+    Path uriPath =
+        absolutePath.startsWith(options.sourceroot)
+            ? options.sourceroot.relativize(absolutePath)
+            : absolutePath;
     StringBuilder out = new StringBuilder();
-    Iterator<Path> it = relativePath.iterator();
+    Iterator<Path> it = uriPath.iterator();
     if (it.hasNext()) out.append(it.next().getFileName().toString());
     while (it.hasNext()) {
       Path part = it.next();
       out.append('/').append(part.getFileName().toString());
     }
     return out.toString();
+  }
+
+  private Path semanticdbPath() {
+    return SemanticdbTaskListener.absolutePathFromUri(options, event.getSourceFile());
   }
 
   private Semanticdb.Documentation semanticdbDocumentation(Symbol sym) {


### PR DESCRIPTION
Previously, the SemanticDB compiler plugin errored when indexing auto-generated files outside of the configured `-sourceroot` directory (which is automatically inferred for Bazel builds). This behavior was undesirable because:

- There's no good workaround for the issue
- The error message was cryptic making it difficult to understand what went wrong

For some cases, we were able to detect this situation for Bazel and ignore the indexed file while printing an informative message, but this behavior was also undesirable because we skipping these files means that we can't render hover messages for symbols in those generated files.

This PR fixes the issue by adding a configurable `-no-relative-path:` flag with the following valid options:

- `index_anyways` (default): indexes the file but with no guarantee that it's possible to recover the location of the original generated file. This allows us to display accurate hover tooltips for symbols in these files even if "Go to definition" won't work.
- `skip`: silently ignored these files.
- `warning`: ignore these files and print a message explaining it was skipped.
- `error`: fail the compilation process (old default).

### Test plan

Manually tested this in the example Bazel workspace with the following commands:
```
❯ cd examples/bazel-example
❯ bazel build //... --@scip_java//semanticdb-javac:enabled=true
INFO: Analyzed 4 targets (0 packages loaded, 0 targets configured).
INFO: Found 4 targets...
INFO: Elapsed time: 0.102s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
❯ find bazel-bin/ -type f -name '*.semanticdb'
bazel-bin//src/main/java/example/example.semanticdb/META-INF/semanticdb/src/main/java/example/Example.java.semanticdb
bazel-bin//src/main/java/example/_javac/example/libexample_classes/META-INF/semanticdb/src/main/java/example/Example.java.semanticdb
bazel-bin//src/main/java/source-generator-example/animal.semanticdb/META-INF/semanticdb/src/main/java/source-generator-example/Animal.java.semanticdb
bazel-bin//src/main/java/source-generator-example/_javac/animal/libanimal_classes/META-INF/semanticdb/bazel-out/darwin_arm64-fastbuild/bin/src/main/java/source-generator-example/_javac/animal/libanimal_sources/AutoValue_Animal.java.semanticdb
bazel-bin//src/main/java/source-generator-example/_javac/animal/libanimal_classes/META-INF/semanticdb/src/main/java/source-generator-example/Animal.java.semanticdb
```

Observe that the generated file does not use the `no-relative-path/NUMBER.FILENAME.semanticdb` logic in this PR. To be sure, I manually tested that code path by changing the implementation a bit and confirmed that it generates valid relative paths under `META-INF/semanticdb/no-relative-path/...`.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
