### PR TITLE
Add mnemonic for scip-java aspect

### DIFF
--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -103,6 +103,7 @@ def _scip_java(target, ctx):
             "JAVA_HOME": ctx.var["java_home"],
             "NO_PROGRESS_BAR": "true",
         },
+        mnemonic = "ScipJavaIndex",
         inputs = depset([build_config_path], transitive = deps),
         outputs = [scip_output, targetroot],
     )


### PR DESCRIPTION
We use mnemonics in the aspect to filter out actions that produce certain kinds of outputs. By providing a mnemonic, we can do the same for the outputs of the scip-java actions (for example, via `bazel aquery`).

### Test plan

n/a
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
