### PR TITLE
Add option --allow-exporting-global-symbols-from-directory-entries

### DIFF
--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/BazelBuildTool.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/BazelBuildTool.java
@@ -65,7 +65,9 @@ public class BazelBuildTool {
             mavenPackages,
             /* buildKind */ "",
             /* emitInverseRelationships */ true,
-            /* allowEmptyIndex */ true);
+            /* allowEmptyIndex */ true,
+            /* indexDirectoryEntries */ false // because Bazel only compiles to jar files.
+            );
     ScipSemanticdb.run(scipOptions);
 
     if (!scipOptions.reporter.hasErrors()) {

--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdbOptions.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdbOptions.java
@@ -19,6 +19,7 @@ public class ScipSemanticdbOptions {
   public final String buildKind;
   public final boolean emitInverseRelationships;
   public final boolean allowEmptyIndex;
+  public final boolean allowExportingGlobalSymbolsFromDirectoryEntries;
 
   public ScipSemanticdbOptions(
       List<Path> targetroots,
@@ -32,7 +33,8 @@ public class ScipSemanticdbOptions {
       List<MavenPackage> packages,
       String buildKind,
       boolean emitInverseRelationships,
-      boolean allowEmptyIndex) {
+      boolean allowEmptyIndex,
+      boolean allowExportingGlobalSymbolsFromDirectoryEntries) {
     this.targetroots = targetroots;
     this.output = output;
     this.sourceroot = sourceroot;
@@ -45,5 +47,7 @@ public class ScipSemanticdbOptions {
     this.buildKind = buildKind;
     this.emitInverseRelationships = emitInverseRelationships;
     this.allowEmptyIndex = allowEmptyIndex;
+    this.allowExportingGlobalSymbolsFromDirectoryEntries =
+        allowExportingGlobalSymbolsFromDirectoryEntries;
   }
 }

--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 import java.{util => ju}
 
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 import com.sourcegraph.scip_java.BuildInfo
 import org.gradle.api.DefaultTask
@@ -12,6 +13,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.provider.Property
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.scala.ScalaCompile
@@ -396,8 +400,43 @@ class WriteDependencies extends DefaultTask {
       .foreach(path => java.nio.file.Files.createDirectories(path.getParent()))
 
     val deps = List.newBuilder[String]
+    val project = getProject()
 
-    getProject()
+    // List the project itself as a dependency so that we can assign project name/version to symbols that are defined in this project.
+    // The code below is roughly equivalent to the following with Groovy:
+    //   deps += "$publication.groupId $publication.artifactId $publication.version $sourceSets.main.output.classesDirectory"
+    Try(
+      project
+        .getExtensions()
+        .getByType(classOf[SourceSetContainer])
+        .getByName("main")
+        .getOutput()
+        .getClassesDirs()
+        .getFiles()
+        .asScala
+        .toList
+        .map(_.getAbsolutePath())
+        .sorted
+        .headOption
+    ).collect { case Some(classesDirectory) =>
+      project
+        .getExtensions()
+        .findByType(classOf[PublishingExtension])
+        .getPublications()
+        .withType(classOf[MavenPublication])
+        .asScala
+        .foreach { publication =>
+          deps +=
+            List(
+              publication.getGroupId(),
+              publication.getArtifactId(),
+              publication.getVersion(),
+              classesDirectory
+            ).mkString("\t")
+        }
+    }
+
+    project
       .getConfigurations()
       .forEach { conf =>
         if (conf.isCanBeResolved()) {

--- a/tests/buildTools/src/test/scala/tests/BaseBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/BaseBuildToolSuite.scala
@@ -111,7 +111,7 @@ abstract class BaseBuildToolSuite extends MopedSuite(ScipJava.app) {
       }
       if (expectedPackages.nonEmpty) {
         val obtainedPackages = ClasspathEntry
-          .fromTargetroot(targetroot)
+          .fromTargetroot(targetroot, workingDirectory)
           .map(_.toPackageHubId)
           .sorted
           .distinct

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -50,6 +50,35 @@ abstract class GradleBuildToolSuite(allGradle: List[String])
     gradleVersions = List(Gradle8, Gradle7, Gradle67)
   )
 
+  checkGradleBuild(
+    "publishing",
+    """|/build.gradle
+       |plugins {
+       |    id 'java'
+       |    id 'maven-publish'
+       |}
+       |repositories {
+       |    // Use Maven Central for resolving dependencies.
+       |    mavenCentral()
+       |}
+       |publishing {
+       |    publications {
+       |        maven(MavenPublication) {
+       |            groupId = 'com.sourcegraph'
+       |            artifactId = 'example-library'
+       |            version = '1.1'
+       |        }
+       |    }
+       |}
+       |/src/main/java/test/ExampleClass.java
+       |package test;
+       |public abstract class ExampleClass {}
+    """.stripMargin,
+    expectedSemanticdbFiles = 1,
+    gradleVersions = List(Gradle8, Gradle7, Gradle67),
+    expectedPackages = "maven:com.sourcegraph:example-library:1.1"
+  )
+
   // This is the most basic test for Java/Scala support
   // We run it for an extended list of Gradle versions
   checkGradleBuild(

--- a/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -24,7 +24,8 @@ class MavenBuildToolSuite extends BaseBuildToolSuite {
         |""".stripMargin,
     2,
     expectedPackages =
-      """|maven:junit:junit:4.11
+      """|maven:com.sourcegraph:example:1.0-SNAPSHOT
+         |maven:junit:junit:4.11
          |maven:org.hamcrest:hamcrest-core:1.3
          |""".stripMargin
   )


### PR DESCRIPTION
Previously, scip-java only allowed cross-index (or cross-repo) navigation between symbols that are compiled to classfiles inside jar files. This behavior mixed an intentional design decision with an accidental implementation detail. The intentional design decision was that the ideal cross-repo navigation experience is from repositories to packages. To achieve this behavior, scip-java didn't assign a package name and package version to symbols that are compiled to directory entries on the classpath.  The accidental implementation detail was that Gradle, Maven, and sbt compile to directories while packages only have jar files.

This commit changes the behavior to treat symbols the same regardless if they are compiled to jar files or directories. The accidental implemenation detail was a hack, and this behavior has come up as a surprise in at least twice cases of trying to integrate scip-java with big propriatery codebases. To get the default old behavior, the flag `--allow-exporting-global-symbols-from-directory-entries` can be set to false.

### Test plan

See updated Gradle and Maven tests.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
