### PR TITLE
Remove unnecessary throw for unexpected exception

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -74,7 +74,6 @@ public final class SemanticdbTaskListener implements TaskListener {
                 String.valueOf(e.getSourceFile().toUri().toString()), throwable);
       }
       this.reportException(throwable, e);
-      throw new RuntimeException(ex.getMessage(), throwable);
     }
   }
 


### PR DESCRIPTION
The motivation to remove this statement is that we shouldn't fail the entire compilation because something unexpected happened for a single file. We're already logging the exception. This statement was a leftover that should have been removed. 

### Test plan
Green CI.


<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
