### PR TITLE
Bazel: fallback to default absolute path logic 

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -146,10 +146,10 @@ public final class SemanticdbTaskListener implements TaskListener {
           return options.sourceroot.resolve(path);
         }
       }
-      throw new IllegalArgumentException("unsupported source file: " + toString);
-    } else {
-      return Paths.get(uri);
+      // Fallback to default behavior.
     }
+
+    return Paths.get(uri);
   }
 
   // Infers the `-sourceroot:` flag from the provided file.

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -74,7 +74,6 @@ public final class SemanticdbTaskListener implements TaskListener {
                 String.valueOf(e.getSourceFile().toUri().toString()), throwable);
       }
       this.reportException(throwable, e);
-      throw new RuntimeException(ex.getMessage(), throwable);
     }
   }
 


### PR DESCRIPTION
Previously, we failed compilation when failing to infer the absolute
path of a file that was being compiled by Bazel. This commit changes the
behavior to fallback to the default behavior, which uses the standard
`JavaFileObject.toUri()` API. The goal of this change is to fix an issue
that happened when using errorprone together with semanticdb-javac, and
errorprone triggers compilation with custom compilation unit here

https://sourcegraph.com/github.com/google/error-prone@77ba705df2c213eddd5652622336f4a8fef3c387/-/blob/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
### Test plan

Green CI.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
