### PR TITLE
Get benchmarks running correctly

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
@@ -5,8 +5,6 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
@@ -30,8 +28,6 @@ public class SemanticdbJavacOptions {
   public UriScheme uriScheme = UriScheme.DEFAULT;
   public NoRelativePathMode noRelativePath = NoRelativePathMode.INDEX_ANYWAY;
   public Path generatedTargetRoot;
-
-  public static String stubClassName = "META-INF-semanticdb-stub";
 
   public SemanticdbJavacOptions() {
     errors = new ArrayList<>();
@@ -133,9 +129,11 @@ public class SemanticdbJavacOptions {
     try {
       JavaFileManager fm = ctx.get(JavaFileManager.class);
       FileObject sourceOutputDirStub =
-          fm.getJavaFileForOutput(SOURCE_OUTPUT, stubClassName, JavaFileObject.Kind.SOURCE, null);
+          fm.getJavaFileForOutput(
+              SOURCE_OUTPUT, SemanticdbPlugin.stubClassName, JavaFileObject.Kind.SOURCE, null);
       FileObject clasSOutputDirStub =
-          fm.getJavaFileForOutput(CLASS_OUTPUT, stubClassName, JavaFileObject.Kind.CLASS, null);
+          fm.getJavaFileForOutput(
+              CLASS_OUTPUT, SemanticdbPlugin.stubClassName, JavaFileObject.Kind.CLASS, null);
       classOutputDir = Paths.get(clasSOutputDirStub.toUri()).toAbsolutePath().getParent();
       sourceOutputDir = Paths.get(sourceOutputDirStub.toUri()).toAbsolutePath().getParent();
     } catch (Exception e) {

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbPlugin.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbPlugin.java
@@ -9,6 +9,8 @@ import com.sun.tools.javac.util.Options;
 /** Entrypoint of the semanticdb-javac compiler plugin. */
 public class SemanticdbPlugin implements Plugin {
 
+  public static String stubClassName = "META-INF-semanticdb-stub";
+
   @Override
   public String getName() {
     return "semanticdb";

--- a/tests/unit/src/main/scala/tests/SimpleFileManager.java
+++ b/tests/unit/src/main/scala/tests/SimpleFileManager.java
@@ -9,10 +9,9 @@ import javax.tools.ForwardingJavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 
-import com.sourcegraph.semanticdb_javac.SemanticdbJavacOptions;
+import com.sourcegraph.semanticdb_javac.SemanticdbPlugin;
 
-public class SimpleFileManager
-    extends ForwardingJavaFileManager<StandardJavaFileManager> {
+public class SimpleFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
 
   public final List<SimpleClassFile> compiled = new ArrayList<>();
   public final Path targetroot;
@@ -25,15 +24,13 @@ public class SimpleFileManager
   // standard constructors/getters
 
   @Override
-  public JavaFileObject getJavaFileForOutput(Location location,
-                                             String className, JavaFileObject.Kind kind, FileObject sibling) {
+  public JavaFileObject getJavaFileForOutput(
+      Location location, String className, JavaFileObject.Kind kind, FileObject sibling) {
     URI uri = targetroot.resolve(className).toUri();
     SimpleClassFile result = new SimpleClassFile(uri);
-    if (!className.equals(SemanticdbJavacOptions.stubClassName)) {
+    if (!className.equals(SemanticdbPlugin.stubClassName)) {
       compiled.add(result);
     }
     return result;
   }
-
 }
-


### PR DESCRIPTION
Previously, the benchmarks were crashing because they accessed classes that are shaded. This commit fixes the problem by moving a public member of a shaded class to another class that is not shaded.

### Test plan

n/a. We don't test the benchmarks in CI because they are too slow to run.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
