### PR TITLE
Run sample benchmarks on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,19 @@ jobs:
       - name: Main project tests
         run: sbt test
 
+  benchmarks-test:
+    runs-on: ubuntu-latest
+    name: Benchmark tests
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: 17
+      - name: Run sample benchmarks
+        run: sbt 'bench/Jmh/run -i 1 -f1 -t1 -foe true'
+
   docker_test:
     runs-on: ${{ matrix.os }}
     name: Docker CLI tests

--- a/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
+++ b/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
@@ -51,12 +51,12 @@ class ScipSemanticdbBench {
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def protobufParallel(): Unit = run("index.scip-protobuf", parallel = true)
+  def protobufParallel(): Unit = run("index.lsif-protobuf", parallel = true)
 
   @Benchmark
   @BenchmarkMode(Array(Mode.SingleShotTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def protobuf(): Unit = run("index.scip-protobuf", parallel = false)
+  def protobuf(): Unit = run("index.lsif-protobuf", parallel = false)
 
   private def run(filename: String, parallel: Boolean): Unit = {
     val output = Files.createTempFile("scip-java", filename)

--- a/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
+++ b/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
@@ -48,16 +48,6 @@ class ScipSemanticdbBench {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def json(): Unit = run("index.scip", parallel = false)
 
-  @Benchmark
-  @BenchmarkMode(Array(Mode.SingleShotTime))
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def protobufParallel(): Unit = run("index.lsif-protobuf", parallel = true)
-
-  @Benchmark
-  @BenchmarkMode(Array(Mode.SingleShotTime))
-  @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  def protobuf(): Unit = run("index.lsif-protobuf", parallel = false)
-
   private def run(filename: String, parallel: Boolean): Unit = {
     val output = Files.createTempFile("scip-java", filename)
     val parallelFlag =

--- a/tests/unit/src/main/scala/tests/CompileResult.scala
+++ b/tests/unit/src/main/scala/tests/CompileResult.scala
@@ -8,8 +8,10 @@ case class CompileResult(
     textDocuments: Semanticdb.TextDocuments,
     isSuccess: Boolean
 ) {
-  def textDocument: Semanticdb.TextDocument = {
-    textDocuments.getDocuments(0)
+  def textDocument: Option[Semanticdb.TextDocument] = {
+    Option.when(textDocuments.getDocumentsCount() > 0) {
+      textDocuments.getDocuments(0)
+    }
   }
 
   def merge(other: CompileResult): CompileResult = {

--- a/tests/unit/src/test/scala/tests/OverridesSuite.scala
+++ b/tests/unit/src/test/scala/tests/OverridesSuite.scala
@@ -26,7 +26,7 @@ class OverridesSuite extends FunSuite with TempDirectories {
       val relativePath = "example.Parent".replace('.', '/') + ".java"
       val input = Input.VirtualFile(relativePath, source)
       val result = compiler.compileSemanticdb(List(input))
-      val symtab = new Symtab(result.textDocument)
+      val symtab = new Symtab(result.textDocument.orNull)
 
       val expectedSyms = expectedSymbols.mkString("\n")
       val syms = symtab

--- a/tests/unit/src/test/scala/tests/TargetedSuite.scala
+++ b/tests/unit/src/test/scala/tests/TargetedSuite.scala
@@ -44,7 +44,8 @@ class TargetedSuite extends FunSuite with TempDirectories {
           })
           .toList
       val result = compiler.compileSemanticdb(List(input))
-      val occurrences = result.textDocument.getOccurrencesList.asScala.toList
+      val textDocument = result.textDocument.orNull
+      val occurrences = textDocument.getOccurrencesList.asScala.toList
       val symbols: List[String] = positions.map { pos =>
         val posRange = Semanticdb
           .Range
@@ -74,7 +75,7 @@ class TargetedSuite extends FunSuite with TempDirectories {
             )
         }
       }
-      fn(result.textDocument, symbols)
+      fn(textDocument, symbols)
     }
   }
 


### PR DESCRIPTION
Additionally, fix benchmarks which used to fail immediately.

This is the full set that was supposed to be running:

```
[info] Benchmark                                 (lib)  Mode  Cnt     Score      Error  Units
[info] CompileBench.compile                  bytebuddy    ss    5  1595.107 ±  180.417  ms/op
[info] CompileBench.compile                      guava    ss    5  1916.022 ±  216.242  ms/op
[info] CompileBench.compileSemanticdb        bytebuddy    ss    5  2105.174 ±  585.412  ms/op
[info] CompileBench.compileSemanticdb            guava    ss    5  2583.266 ±  196.088  ms/op
[info] ScipSemanticdbBench.json                    N/A    ss    5  1870.098 ±  468.124  ms/op
[info] ScipSemanticdbBench.jsonParallel            N/A    ss    5  2918.148 ± 1331.300  ms/op
[info] ScipSemanticdbBench.protobuf                N/A    ss    5   964.729 ±  339.123  ms/op
[info] ScipSemanticdbBench.protobufParallel        N/A    ss    5   844.251 ±  197.321  ms/op
```

### Test plan

CI is my test plan.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
