### PR TITLE
Allow custom dependency repositories in SCIP build tool

### DIFF
--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/Dependencies.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/Dependencies.scala
@@ -4,11 +4,11 @@ import java.io.File
 import java.nio.file.Path
 
 import coursier.Fetch
+import coursier.LocalRepositories
 import coursier.Repositories
 import coursier.Resolve
 import coursier.core._
 import coursier.maven.MavenRepository
-import coursier.LocalRepositories
 
 case class Dependencies(
     dependencies: List[Dependency],

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/Dependencies.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/Dependencies.scala
@@ -8,6 +8,7 @@ import coursier.Repositories
 import coursier.Resolve
 import coursier.core._
 import coursier.maven.MavenRepository
+import coursier.LocalRepositories
 
 case class Dependencies(
     dependencies: List[Dependency],
@@ -38,12 +39,13 @@ object Dependencies {
       case None =>
         Resolve.defaultRepositories.toList ++ defaultExtraRepositories
       case Some(value) =>
-        value.map {
-          case "central" =>
-            Repositories.central
-          case other =>
-            MavenRepository(other): Repository
-        }
+        LocalRepositories.ivy2Local +:
+          value.map {
+            case "central" =>
+              Repositories.central
+            case other =>
+              MavenRepository(other): Repository
+          }
 
     }
 

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/Dependencies.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/Dependencies.scala
@@ -3,19 +3,11 @@ package com.sourcegraph.scip_java
 import java.io.File
 import java.nio.file.Path
 
-import scala.concurrent.duration.Duration
-import scala.util.Try
-import scala.xml.XML
-
 import coursier.Fetch
 import coursier.Repositories
 import coursier.Resolve
-import coursier.cache.Cache
-import coursier.cache.CachePolicy
-import coursier.cache.FileCache
 import coursier.core._
-import coursier.parse.DependencyParser
-import coursier.util.Task
+import coursier.maven.MavenRepository
 
 case class Dependencies(
     dependencies: List[Dependency],
@@ -29,118 +21,31 @@ case class Dependencies(
 
 object Dependencies {
   val empty = Dependencies(Nil, Fetch.Result(), Fetch.Result())
-  private val cache: FileCache[Task] = FileCache[Task]()
-    .noCredentials
-    .withCachePolicies(List(CachePolicy.LocalOnly, CachePolicy.Update))
-    .withTtl(Duration.Inf)
-    .withChecksums(Nil)
-  private val defaultExtraRepositories = List[Repository](
-    Repositories.google,
-    Repositories.clojars,
-    Repositories.jitpack,
-    Repositories.centralGcs
-  )
+  def resolver(userRepositories: Option[List[String]]) =
+    new DependenciesResolver(calculateRepositories(userRepositories))
 
-  /**
-   * Attempts to find the "common definitions" JAR for a potentially
-   * MultiPlatform Project. We only support JVM for now, native and JS are not
-   * supported. If it ends with '-jvm', we search for a JAR with the classifier
-   * truncated. If it does not end with -jvm, we search for a JAR with the
-   * -common classifier. This is non-exhaustive, and the classifiers are
-   * completely arbitrary.
-   */
-  def kotlinMPPCommon(
-      group: String,
-      artifact: String,
-      version: String
-  ): Option[Path] =
-    Try {
-      val task = Fetch[Task](Cache.default)
-        .withClassifiers(Set(Classifier.sources))
-        .addRepositories(defaultExtraRepositories: _*)
-
-      if (artifact.endsWith("-jvm")) {
-        val dependency = Dependencies
-          .parseDependency(s"$group:${artifact.stripSuffix("-jvm")}:$version")
-        val result = task.addDependencies(dependency).runResult()
-        return Some(result.files.head.toPath)
-      }
-
-      val dependency = Dependencies
-        .parseDependency(s"$group:$artifact-common:$version")
-      val result = task.addDependencies(dependency).runResult()
-      result.files.head.toPath
-    }.toOption
-
-  def resolveDependencies(
-      dependencies: List[String],
-      transitive: Boolean = true
-  ): Dependencies = {
-    val deps = dependencies.map(parseDependency)
-    val provided = deps.flatMap(d => resolveProvidedDeps(d))
-    def nonTransitiveDeps = deps.map(_.withTransitive(false))
-    val fetch = Fetch[Task](Cache.default)
-      .addDependencies(deps: _*)
-      .addDependencies(provided: _*)
-      .addRepositories(defaultExtraRepositories: _*)
-
-    val classpath = fetch.runResult()
-    val sources = fetch
-      .withDependencies(
-        if (transitive)
-          fetch.dependencies
-        else
-          nonTransitiveDeps
-      )
-      .withClassifiers(Set(Classifier.sources))
-      .runResult()
-    Dependencies(
-      dependencies = deps,
-      sourcesResult = sources,
-      classpathResult = classpath
+  private def calculateRepositories(
+      userRepositories: Option[List[String]]
+  ): List[Repository] = {
+    val defaultExtraRepositories = List[Repository](
+      Repositories.google,
+      Repositories.clojars,
+      Repositories.jitpack,
+      Repositories.centralGcs
     )
-  }
 
-  def resolveProvidedDeps(dep: Dependency): Seq[Dependency] = {
-    val artifacts = Resolve[Task](Cache.default)
-      .addDependencies(dep)
-      .addRepositories(defaultExtraRepositories: _*)
-      .run()
-      .artifacts()
-    for {
-      artifact <- artifacts
-      metadata <- artifact.extra.get("metadata").toList
-      file = cache.localFile(metadata.url)
-      dep <- parseProvidedDependencies(file)
-    } yield dep
-  }
+    userRepositories match {
+      case None =>
+        Resolve.defaultRepositories.toList ++ defaultExtraRepositories
+      case Some(value) =>
+        value.map {
+          case "central" =>
+            Repositories.central
+          case other =>
+            MavenRepository(other): Repository
+        }
 
-  private def parseProvidedDependencies(file: File): List[Dependency] = {
-    for {
-      dep <- XML.loadFile(file) \ "dependencies" \ "dependency"
-      if (dep \ "scope").text == "provided"
-      org = (dep \ "groupId").text
-      module = (dep \ "artifactId").text
-      version = (dep \ "version").text
-      if org.nonEmpty && module.nonEmpty && version.nonEmpty &&
-        !version.startsWith("${")
-    } yield Dependency(
-      Module(Organization(org), ModuleName(module), Map.empty),
-      version
-    )
-  }.toList
-
-  def parseDependencyEither(lib: String): Either[String, Dependency] = {
-    DependencyParser
-      .dependency(lib, defaultScalaVersion = BuildInfo.scalaVersion)
-  }
-
-  private def parseDependency(lib: String): Dependency = {
-    parseDependencyEither(lib) match {
-      case Left(error) =>
-        throw new IllegalArgumentException(error)
-      case Right(value) =>
-        value
     }
+
   }
 }

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/DependenciesResolver.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/DependenciesResolver.scala
@@ -1,14 +1,16 @@
 package com.sourcegraph.scip_java
 
+import java.io.File
+import java.nio.file.Path
+
+import scala.concurrent.duration.Duration
+import scala.util.Try
+import scala.xml.XML
+
 import coursier._
 import coursier.cache._
-import coursier.util.Task
-import scala.concurrent.duration.Duration
-import java.nio.file.Path
-import scala.util.Try
-import java.io.File
-import scala.xml.XML
 import coursier.parse.DependencyParser
+import coursier.util.Task
 
 class DependenciesResolver(repositories: List[Repository]) {
   private val cache: FileCache[Task] = FileCache[Task]()

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/DependenciesResolver.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/DependenciesResolver.scala
@@ -1,0 +1,123 @@
+package com.sourcegraph.scip_java
+
+import coursier._
+import coursier.cache._
+import coursier.util.Task
+import scala.concurrent.duration.Duration
+import java.nio.file.Path
+import scala.util.Try
+import java.io.File
+import scala.xml.XML
+import coursier.parse.DependencyParser
+
+class DependenciesResolver(repositories: List[Repository]) {
+  private val cache: FileCache[Task] = FileCache[Task]()
+    .noCredentials
+    .withCachePolicies(List(CachePolicy.LocalOnly, CachePolicy.Update))
+    .withTtl(Duration.Inf)
+    .withChecksums(Nil)
+
+  /**
+   * Attempts to find the "common definitions" JAR for a potentially
+   * MultiPlatform Project. We only support JVM for now, native and JS are not
+   * supported. If it ends with '-jvm', we search for a JAR with the classifier
+   * truncated. If it does not end with -jvm, we search for a JAR with the
+   * -common classifier. This is non-exhaustive, and the classifiers are
+   * completely arbitrary.
+   */
+  def kotlinMPPCommon(
+      group: String,
+      artifact: String,
+      version: String
+  ): Option[Path] =
+    Try {
+      val task = Fetch[Task](Cache.default)
+        .withClassifiers(Set(Classifier.sources))
+        .withRepositories(repositories)
+
+      if (artifact.endsWith("-jvm")) {
+        val dependency = parseDependency(
+          s"$group:${artifact.stripSuffix("-jvm")}:$version"
+        )
+        val result = task.addDependencies(dependency).runResult()
+        return Some(result.files.head.toPath)
+      }
+
+      val dependency = parseDependency(s"$group:$artifact-common:$version")
+      val result = task.addDependencies(dependency).runResult()
+      result.files.head.toPath
+    }.toOption
+
+  def resolveDependencies(
+      dependencies: List[String],
+      transitive: Boolean = true
+  ): Dependencies = {
+    val deps = dependencies.map(parseDependency)
+    val provided = deps.flatMap(d => resolveProvidedDeps(d))
+    def nonTransitiveDeps = deps.map(_.withTransitive(false))
+    val fetch = Fetch[Task](Cache.default)
+      .addDependencies(deps: _*)
+      .addDependencies(provided: _*)
+      .withRepositories(repositories)
+
+    val classpath = fetch.runResult()
+    val sources = fetch
+      .withDependencies(
+        if (transitive)
+          fetch.dependencies
+        else
+          nonTransitiveDeps
+      )
+      .withClassifiers(Set(Classifier.sources))
+      .runResult()
+    Dependencies(
+      dependencies = deps,
+      sourcesResult = sources,
+      classpathResult = classpath
+    )
+  }
+
+  def resolveProvidedDeps(dep: Dependency): Seq[Dependency] = {
+    val artifacts = Resolve[Task](Cache.default)
+      .addDependencies(dep)
+      .withRepositories(repositories)
+      .run()
+      .artifacts()
+    for {
+      artifact <- artifacts
+      metadata <- artifact.extra.get("metadata").toList
+      file = cache.localFile(metadata.url)
+      dep <- parseProvidedDependencies(file)
+    } yield dep
+  }
+
+  private def parseProvidedDependencies(file: File): List[Dependency] = {
+    for {
+      dep <- XML.loadFile(file) \ "dependencies" \ "dependency"
+      if (dep \ "scope").text == "provided"
+      org = (dep \ "groupId").text
+      module = (dep \ "artifactId").text
+      version = (dep \ "version").text
+      if org.nonEmpty && module.nonEmpty && version.nonEmpty &&
+        !version.startsWith("${")
+    } yield Dependency(
+      Module(Organization(org), ModuleName(module), Map.empty),
+      version
+    )
+  }.toList
+
+  def parseDependencyEither(lib: String): Either[String, Dependency] = {
+    DependencyParser
+      .dependency(lib, defaultScalaVersion = BuildInfo.scalaVersion)
+  }
+
+  private def parseDependency(lib: String): Dependency = {
+    parseDependencyEither(lib) match {
+      case Left(error) =>
+        throw new IllegalArgumentException(error)
+      case Right(value) =>
+        value
+    }
+  }
+
+}

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/buildtools/ScipBuildTool.scala
@@ -36,6 +36,7 @@ import com.sourcegraph.io.AbsolutePath
 import com.sourcegraph.io.DeleteVisitor
 import com.sourcegraph.scip_java.BuildInfo
 import com.sourcegraph.scip_java.Dependencies
+import com.sourcegraph.scip_java.DependenciesResolver
 import com.sourcegraph.scip_java.Embedded
 import com.sourcegraph.scip_java.commands.IndexCommand
 import com.sourcegraph.semanticdb_javac.Semanticdb.TextDocument
@@ -62,7 +63,6 @@ import org.jetbrains.kotlin.config.Services
 import os.CommandResult
 import os.ProcessOutput.Readlines
 import os.SubprocessException
-import com.sourcegraph.scip_java.DependenciesResolver
 
 /**
  * A custom build tool that is specifically made for scip-java.

--- a/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexDependencyCommand.scala
+++ b/scip-java/src/main/scala/com/sourcegraph/scip_java/commands/IndexDependencyCommand.scala
@@ -15,9 +15,9 @@ import com.sourcegraph.scip_semanticdb.JavaVersion
 import moped.annotations.DeprecatedName
 import moped.annotations.Description
 import moped.annotations.Hidden
+import moped.annotations.Repeated
 import moped.cli.Command
 import moped.cli.CommandParser
-import moped.annotations.Repeated
 
 final case class IndexDependencyCommand(
     @DeprecatedName("target", "Use --output instead", "0.6.10") output: Path =

--- a/tests/benchmarks/src/main/scala/benchmarks/CompileBench.scala
+++ b/tests/benchmarks/src/main/scala/benchmarks/CompileBench.scala
@@ -33,7 +33,7 @@ class CompileBench {
   @Setup()
   def setup(): Unit = {
     tmp = Files.createTempDirectory("benchmarks")
-    deps = Dependencies.resolveDependencies(List(libs(lib)))
+    deps = Dependencies.resolver(None).resolveDependencies(List(libs(lib)))
     compiler =
       new TestCompiler(
         deps.classpathSyntax,

--- a/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
+++ b/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
@@ -20,7 +20,8 @@ class ScipSemanticdbBench {
   def setup(): Unit = {
     targetroot = Files.createTempDirectory("scip-java")
     deps = Dependencies
-      .resolver(None).resolveDependencies(List("com.google.guava:guava:30.1-jre"))
+      .resolver(None)
+      .resolveDependencies(List("com.google.guava:guava:30.1-jre"))
     val compiler =
       new TestCompiler(
         deps.classpathSyntax,

--- a/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
+++ b/tests/benchmarks/src/main/scala/benchmarks/ScipSemanticdbBench.scala
@@ -20,7 +20,7 @@ class ScipSemanticdbBench {
   def setup(): Unit = {
     targetroot = Files.createTempDirectory("scip-java")
     deps = Dependencies
-      .resolveDependencies(List("com.google.guava:guava:30.1-jre"))
+      .resolver(None).resolveDependencies(List("com.google.guava:guava:30.1-jre"))
     val compiler =
       new TestCompiler(
         deps.classpathSyntax,


### PR DESCRIPTION
Previously, when resolving dependencies, we used the following repositories by default:

1. Maven Central
2. Extra repositories such as jitpack, clojars, google's maven repo, etc.

This was (I believe) done for convenience.

There was no way to configure repositories, namely to fully override that list to, for example, avoid Coursier ever going through public repos.

This PR does the following:

- Adds `repositories` (type: array of string) field to `lsif-java.json` with the following semantics:
  - If the field is set, this **fully** overrides the list of remote repositories that will be used (ivy2 local will still be added)
  - if the field is not set, we fall back to previous behaviour: central + ivy2local + some extra remote repos
  - the value `"central"` is handled in a special way in the list and will be resolved to maven central
- Adds `--repositories` repeated flag to `index-dependency` CLI command, with the same behaviour as above: `index-dependency --dependency com.google.code.findbugs:jsr305:3.0.2 --repositories central --repositories http://localhost/bla`
- Refactoring: move the resolving logic to a separate class so we can ensure the repositories are shared

### Test plan

New automated tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
