### PR TITLE
Unconditionally add agent in Gradle plugin, add protobuf codegen test

### DIFF
--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -170,6 +170,17 @@ class SemanticdbGradlePlugin extends Plugin[Project] {
                   ).asJava
                 )
             }
+
+            /**
+             * In some yet to be understood cases we see that compiler plugin
+             * can be added successfully, but the correct flags are still not
+             * propagated.
+             *
+             * To work around it, we enable the agent unconditionally, and then
+             * if necessary deduplicate the arguments.
+             *
+             * TODO: figure out why this is necessary
+             */
             agentJar.foreach { agentpath =>
               javacPluginJar.foreach { pluginpath =>
                 val jvmArgs = task.getOptions.getForkOptions.getJvmArgs

--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -154,7 +154,7 @@ class SemanticdbGradlePlugin extends Plugin[Project] {
             task.getOptions().setFork(true)
             task.getOptions().setIncremental(false)
 
-            if (compilerPluginAdded)
+            if (compilerPluginAdded) {
               task
                 .getOptions()
                 .getCompilerArgs()
@@ -169,21 +169,21 @@ class SemanticdbGradlePlugin extends Plugin[Project] {
                     s"-Xplugin:semanticdb -targetroot:$targetRoot -sourceroot:$sourceRoot"
                   ).asJava
                 )
-            else
-              agentJar.foreach { agentpath =>
-                javacPluginJar.foreach { pluginpath =>
-                  val jvmArgs = task.getOptions.getForkOptions.getJvmArgs
+            }
+            agentJar.foreach { agentpath =>
+              javacPluginJar.foreach { pluginpath =>
+                val jvmArgs = task.getOptions.getForkOptions.getJvmArgs
 
-                  jvmArgs.addAll(
-                    List(
-                      s"-javaagent:$agentpath",
-                      s"-Dsemanticdb.pluginpath=$pluginpath",
-                      s"-Dsemanticdb.sourceroot=$sourceRoot",
-                      s"-Dsemanticdb.targetroot=$targetRoot"
-                    ).asJava
-                  )
-                }
+                jvmArgs.addAll(
+                  List(
+                    s"-javaagent:$agentpath",
+                    s"-Dsemanticdb.pluginpath=$pluginpath",
+                    s"-Dsemanticdb.sourceroot=$sourceRoot",
+                    s"-Dsemanticdb.targetroot=$targetRoot"
+                  ).asJava
+                )
               }
+            }
 
           }
       }

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -158,6 +158,44 @@ abstract class GradleBuildToolSuite(allGradle: List[String])
   }
 
   checkGradleBuild(
+    "protobuf-generator",
+    """|/build.gradle
+       |plugins {
+       |  id "java"
+       |  id "com.google.protobuf" version "0.9.4"
+       |}
+       |dependencies {
+       |  implementation 'com.google.protobuf:protobuf-javalite:3.8.0'
+       |}
+       |protobuf {
+       |  protoc {
+       |    artifact = 'com.google.protobuf:protoc:3.23.4'
+       |  }
+       |  generateProtoTasks {
+       |    all().configureEach { task ->
+       |      task.builtins {
+       |        java {
+       |          option "lite"
+       |        }
+       |      }
+       |    }
+       |  }
+       |}
+       |/src/main/proto/message.proto
+       |syntax = "proto3";
+       |message SearchRequest {
+       |  string query = 1;
+       |  int32 page_number = 2;
+       |  int32 results_per_page = 3;
+       |}
+       |/src/main/java/Example.java
+       |public class Example {}
+       |""".stripMargin,
+    expectedSemanticdbFiles = 2,
+    gradleVersions = List(Gradle8, Gradle7, Gradle67)
+  )
+
+  checkGradleBuild(
     "explicit",
     """|/build.gradle
        |apply plugin: 'java'


### PR DESCRIPTION
As reported by customer, in some cases Gradle doesn't complain about semanticdb dependency, but doesn't apply it either.

We don't know the case yet, but as a workaround, it's possible to just add agent unconditionally, and apply it only if semanticdb params didn't make it into the javac options

### Test plan

- Additional test
- Existing tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
