### PR TITLE
Be more graceful about cross-repo navigation error

### DIFF
--- a/docs/manual-configuration.md
+++ b/docs/manual-configuration.md
@@ -163,6 +163,7 @@ one of the following files in the SemanticDB _targetroot_ directory (the path in
 
 - `javacopts.txt`: line-separated list of Java compiler options that got passed
   to the compiler. For example,
+
   ```sh
   $ cat $TARGETROOT/javacopts.txt
   -Xlint
@@ -172,22 +173,25 @@ one of the following files in the SemanticDB _targetroot_ directory (the path in
   /path/to/classes/directory
   /path/to/com/example/Main.java
   ```
+
   The `javacopts.txt` file format can only be used if the jars on the dependency
   classpath have sibling `.pom` files. In some build tools like Gradle, the POM
   files are not siblings to the jars on the classpath so the `javacopts.txt`
   format cannot be used.
+
 - `dependencies.txt`: a tab-separated values file where the columns are: group
   ID, artifact ID, version and jar path. For example,
+
   ```sh
   $ cat $TARGETROOT/dependencies.txt
   junit junit 4.13.2  /path/to/junit.jar
   org.hamcrest hamcrest-core 1.3  /path/to/hamcrest-core.jar
   ```
+
   The `dependencies.txt` format is used by scip-java to map symbols such as
-  `org.junit.Assert` to Maven co-ordinates like `junit:junit:4.13.2`. As long as
+  `org.junit.Assert` to Maven coordinates like `junit:junit:4.13.2`. As long as
   your Sourcegraph instance has another repository that defines that symbol, the
-  cross-repository navigation should succeed. Only jar files are supported at
-  the moment, classes directories are ignored.
+  cross-repository navigation should succeed. 
 
 Cross-repository navigation is a feature that allows "goto definition" and "find
 references" to show results from multiple repositories.

--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -5,7 +5,7 @@ import java.nio.file.Paths
 import java.{util => ju}
 
 import scala.jdk.CollectionConverters._
-import scala.util.control.NonFatal
+import scala.util._
 
 import com.sourcegraph.scip_java.BuildInfo
 import org.gradle.api.DefaultTask
@@ -19,7 +19,6 @@ import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.scala.ScalaCompile
-import scala.util._
 
 class SemanticdbGradlePlugin extends Plugin[Project] {
   override def apply(project: Project): Unit = {


### PR DESCRIPTION
Closes #659

Instead of showing a super long stacktrace, we make it clear that this exception is skippable and will only affect cross-repo navigation.

Here's what it will look like now:

![CleanShot 2023-11-01 at 10 56 14](https://github.com/sourcegraph/scip-java/assets/1052965/51c4ee60-8815-460e-b966-e49de7f0b436)

### Test plan

N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
