### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ after we renamed the "Docker container" section into "Docker image". -->
 Use the `sourcegraph/scip-java` Docker image to run `scip-java`.
 
 ```sh
-$ docker run -v $(pwd):/home/gradle --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index
+$ docker run -v $(pwd):/sources --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index
 $ src code-intel upload # (optional) upload index to Sourcegraph
 ```
 
@@ -47,13 +47,13 @@ Use the following commands to use a different JVM version:
 
 ```sh
 # Java 8
-docker run -v $(pwd):/home/gradle --env JVM_VERSION=8 sourcegraph/scip-java:latest scip-java index
+docker run -v $(pwd):/sources --env JVM_VERSION=8 sourcegraph/scip-java:latest scip-java index
 
 # Java 11
-docker run -v $(pwd):/home/gradle --env JVM_VERSION=11 sourcegraph/scip-java:latest scip-java index
+docker run -v $(pwd):/sources --env JVM_VERSION=11 sourcegraph/scip-java:latest scip-java index
 
 # Java 17 (default)
-docker run -v $(pwd):/home/gradle --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index
+docker run -v $(pwd):/sources --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index
 ```
 
 ### Java launcher


### PR DESCRIPTION
Update docker image run command

### Test plan
It seems that the working directory of the `sourcegraph/scip-java` docker image has been moved to `/sources`.
I modified my command to `docker run -v $(pwd):/sources --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index` to index a software project.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->