### PR TITLE
Fix Gradle builds with -Werror

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -357,18 +357,16 @@ lazy val minimizedSettings = List[Def.Setting[_]](
   (run / fork) := true,
   (Compile / unmanagedSourceDirectories) += minimizedSourceDirectory,
   libraryDependencies ++= List("org.projectlombok" % "lombok" % "1.18.22"),
-  javacOptions ++=
-    List[String](
-      s"-Arandomtimestamp=${System.nanoTime()}",
-      List(
-        s"-Xplugin:semanticdb",
-        s"-build-tool:sbt",
-        s"-text:on",
-        s"-verbose",
-        s"-sourceroot:${(ThisBuild / baseDirectory).value}",
-        s"-targetroot:${(Compile / semanticdbTargetRoot).value}"
-      ).mkString(" ")
-    )
+  javacOptions +=
+    List(
+      s"-Xplugin:semanticdb",
+      s"-build-tool:sbt",
+      s"-text:on",
+      s"-verbose",
+      s"-sourceroot:${(ThisBuild / baseDirectory).value}",
+      s"-targetroot:${(Compile / semanticdbTargetRoot).value}",
+      s"-randomtimestamp=${System.nanoTime()}"
+    ).mkString(" ")
 )
 
 lazy val minimized = project

--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -165,8 +165,7 @@ class SemanticdbGradlePlugin extends Plugin[Project] {
                     // TODO: before this plugin is published to Maven Central,
                     // we will need to revert this change - as it can have detrimental
                     // effect on people's builds
-                    s"-Arandomtimestamp=${System.currentTimeMillis()}",
-                    s"-Xplugin:semanticdb -targetroot:$targetRoot -sourceroot:$sourceRoot"
+                    s"-Xplugin:semanticdb -targetroot:$targetRoot -sourceroot:$sourceRoot -randomtimestamp=${System.nanoTime()}"
                   ).asJava
                 )
             }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbJavacOptions.java
@@ -97,6 +97,7 @@ public class SemanticdbJavacOptions {
         result.verboseEnabled = true;
       } else if (arg.equals("-verbose:off")) {
         result.verboseEnabled = false;
+      } else if (arg.startsWith("-randomtimestamp")) {
       } else {
         result.errors.add(String.format("unknown flag '%s'\n", arg));
       }
@@ -126,8 +127,10 @@ public class SemanticdbJavacOptions {
   // warning - use of internal API
   // requires --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
   private static TargetPaths getJavacClassesDir(SemanticdbJavacOptions result, JavacTask task) {
-    // both Context and BasicJavacTask are internal JDK classes so not exported under >= JDK 17
-    //  com.sun.tools.javac.util.Context ctx = ((com.sun.tools.javac.api.BasicJavacTask)
+    // both Context and BasicJavacTask are internal JDK classes so not exported
+    // under >= JDK 17
+    // com.sun.tools.javac.util.Context ctx =
+    // ((com.sun.tools.javac.api.BasicJavacTask)
     // task).getContext();
     // I'm not aware of a better way to get the class output directory from javac
     Path classOutputDir = null;

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -60,14 +60,25 @@ abstract class GradleBuildToolSuite(allGradle: List[String])
        |    // Use Maven Central for resolving dependencies.
        |    mavenCentral()
        |}
+       |dependencies {
+       |  compileOnly 'org.immutables:value:2.9.2'
+       |  annotationProcessor 'org.immutables:value:2.9.2'
+       |}
        |compileJava {
        | options.compilerArgs << "-Werror"
        |}
        |/src/main/java/main/bla/ExampleClass.java
-       |package bla;
-       |public abstract class ExampleClass {}
+       |package test;
+       |import org.immutables.value.Value;
+       |import java.util.Optional;
+       |@Value.Immutable
+       |public abstract class ExampleClass {
+       |    public abstract Optional<String> getWorkflowIdReusePolicy();
+       |}
     """.stripMargin,
-    expectedSemanticdbFiles = 1,
+    // See comment about immutable annotation processor above,
+    // it explains why we expecte 2 semanticdb files
+    expectedSemanticdbFiles = 2,
     gradleVersions = List(Gradle8, Gradle7, Gradle67)
   )
 

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -54,30 +54,17 @@ abstract class GradleBuildToolSuite(allGradle: List[String])
     "build-with-Werror",
     """|/build.gradle
        |plugins {
-<<<<<<< Updated upstream
-       |    id 'java'
-=======
        |    id 'java-library'
->>>>>>> Stashed changes
        |}
        |repositories {
        |    // Use Maven Central for resolving dependencies.
        |    mavenCentral()
        |}
-<<<<<<< Updated upstream
        |compileJava {
        | options.compilerArgs << "-Werror"
        |}
-       |/src/main/java/main/ExampleClass.java
-=======
-       |allprojects {
-       |   tasks.withType(JavaCompile) {
-       |       options.compilerArgs += ['-Xlint:deprecation', '-Werror']
-       |   }
-       |}
-       |/src/main/java/ExampleClass.java
->>>>>>> Stashed changes
-       |package test;
+       |/src/main/java/main/bla/ExampleClass.java
+       |package bla;
        |public abstract class ExampleClass {}
     """.stripMargin,
     expectedSemanticdbFiles = 1,

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -54,16 +54,29 @@ abstract class GradleBuildToolSuite(allGradle: List[String])
     "build-with-Werror",
     """|/build.gradle
        |plugins {
+<<<<<<< Updated upstream
        |    id 'java'
+=======
+       |    id 'java-library'
+>>>>>>> Stashed changes
        |}
        |repositories {
        |    // Use Maven Central for resolving dependencies.
        |    mavenCentral()
        |}
+<<<<<<< Updated upstream
        |compileJava {
        | options.compilerArgs << "-Werror"
        |}
        |/src/main/java/main/ExampleClass.java
+=======
+       |allprojects {
+       |   tasks.withType(JavaCompile) {
+       |       options.compilerArgs += ['-Xlint:deprecation', '-Werror']
+       |   }
+       |}
+       |/src/main/java/ExampleClass.java
+>>>>>>> Stashed changes
        |package test;
        |public abstract class ExampleClass {}
     """.stripMargin,

--- a/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/GradleBuildToolSuite.scala
@@ -51,6 +51,27 @@ abstract class GradleBuildToolSuite(allGradle: List[String])
   )
 
   checkGradleBuild(
+    "build-with-Werror",
+    """|/build.gradle
+       |plugins {
+       |    id 'java'
+       |}
+       |repositories {
+       |    // Use Maven Central for resolving dependencies.
+       |    mavenCentral()
+       |}
+       |compileJava {
+       | options.compilerArgs << "-Werror"
+       |}
+       |/src/main/java/main/ExampleClass.java
+       |package test;
+       |public abstract class ExampleClass {}
+    """.stripMargin,
+    expectedSemanticdbFiles = 1,
+    gradleVersions = List(Gradle8, Gradle7, Gradle67)
+  )
+
+  checkGradleBuild(
     "publishing",
     """|/build.gradle
        |plugins {


### PR DESCRIPTION
## Problem

It turns out that under `-Werror`, the warning that javac emits when encountering our hacky `-Arandomtimestamp=<bla>` parameter causes the indexing to fail.

For an example of that, consider https://github.com/palantir/refreshable:

- Run `cs launch scip-java:0.9.7 --contrib --scala 2.13.12 -- index` where `cs` is [Coursier](https://get-coursier.io/)
- Bunch of output, but the main bit is:
```
> Task :refreshable:compileTestJava FAILED
warning: The following options were not recognized by any processor: '[randomtimestamp]'
error: warnings found and -Werror specified
1 error
1 warning
```

### Why do we have this `-Arandomtimestamp` at all?

It's there to ensure that Gradle doesn't cache the compilation results at all, as it can lead to a very frustrating experience of not seeing semanticdb files produced despite making changes to the build.

Note - gradle's `clean` command doesn't clean the particular cache affected by this, neither does `--no-daemon` option - we already have both of those in auto-indexing and caches still persist between runs without modifying javac options

### Alternatives rejected

- Attempting to remove the `-Werror` flag from the compilation arguments
  
  Rejected because historically any modifications to gradle javac flags have been brittle and required hacks. Additionally, there may be builds that assert that the code is compiled with certain flags in CI, and we don't want to make any further modifications to the build 
unless it's necessary

- Making CLI argument parsing in scip-java-semanticdb more lenient to accept anything

  Rejected because we want to be strict in what arguments are being passed into the plugin, given how already difficult it is to debug compiler plugin pipeline and how much damage one can do by misspelling a parameter (i.e. putting files silently in wrong path)

- Removing this entirely and instead realying on a magical env variable

  Weakly rejected because magical env variables will require documentation for development - as opposed to a magical "always on" parameter that affects nothing but the plugin and doesn't exist anywhere but during the single gradle run for auto-indexing. The latter seems better.



### Test plan

- new minimal reproduction test was added, tested on Gradle 6/7/8

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
