### PR TITLE
Fix "Find references" bug for interfaces and types

### DIFF
--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/ScipSemanticdb.java
@@ -441,6 +441,8 @@ public class ScipSemanticdb {
 
   private static boolean supportsReferenceRelationship(SymbolInformation info) {
     switch (info.getKind()) {
+      case INTERFACE:
+      case TYPE:
       case CLASS:
       case OBJECT:
       case PACKAGE_OBJECT:

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/BaseEpoxyTouchCallback.java
@@ -8,8 +8,6 @@ import android.view.View;
 interface BaseEpoxyTouchCallback<T extends EpoxyModel> {
 //        ^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                               documentation ```java\ninterface BaseEpoxyTouchCallback<T extends EpoxyModel>\n```
-//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#
-//                               relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#
 //                               ^ definition semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#[T]
 //                                 documentation ```java\nT extends EpoxyModel\n```
 //                                         ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyController.java
@@ -302,7 +302,7 @@ public abstract class EpoxyController implements ModelCollector, StickyHeaderCal
 // ^^^^^^ reference semanticdb maven maven/androidx.annotation/annotation 1.1.0 androidx/annotation/IntDef#
 //         ^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
 //                                 documentation ```java\n@Retention(RetentionPolicy.SOURCE)\n@IntDef({RequestedModelBuildType.NONE, RequestedModelBuildType.NEXT_FRAME, RequestedModelBuildType.DELAYED})\nprivate @interface RequestedModelBuildType\n```
-//                                 relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+//                                 relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
 //         ^^^^^^^^^^^^^^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#
 //                                 ^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyController#RequestedModelBuildType#NONE.
       RequestedModelBuildType.NEXT_FRAME,

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDragCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxyDragCallback.java
@@ -12,7 +12,7 @@ public interface EpoxyDragCallback<T extends EpoxyModel> extends BaseEpoxyTouchC
 //               ^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#
 //                                 documentation ```java\npublic interface EpoxyDragCallback<T extends EpoxyModel>\n```
 //                                 documentation  For use with {@link EpoxyModelTouchCallback}\n
-//                                 relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#
+//                                 relationship is_implementation semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                                 ^ definition semanticdb maven . . com/airbnb/epoxy/EpoxyDragCallback#[T]
 //                                   documentation ```java\nT extends EpoxyModel\n```
 //                                           ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxySwipeCallback.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/EpoxySwipeCallback.java
@@ -22,7 +22,7 @@ public interface EpoxySwipeCallback<T extends EpoxyModel> extends BaseEpoxyTouch
 //               ^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#
 //                                  documentation ```java\npublic interface EpoxySwipeCallback<T extends EpoxyModel>\n```
 //                                  documentation  For use with {@link EpoxyModelTouchCallback}\n
-//                                  relationship is_reference is_implementation semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#
+//                                  relationship is_implementation semanticdb maven . . com/airbnb/epoxy/BaseEpoxyTouchCallback#
 //                                  ^ definition semanticdb maven . . com/airbnb/epoxy/EpoxySwipeCallback#[T]
 //                                    documentation ```java\nT extends EpoxyModel\n```
 //                                            ^^^^^^^^^^ reference semanticdb maven . . com/airbnb/epoxy/EpoxyModel#

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/UpdateOp.java
@@ -44,7 +44,7 @@ class UpdateOp {
   @interface Type {
 //           ^^^^ definition semanticdb maven . . com/airbnb/epoxy/UpdateOp#Type#
 //                documentation ```java\n@IntDef({ADD, REMOVE, UPDATE, MOVE})\n@Retention(RetentionPolicy.SOURCE)\n@interface Type\n```
-//                relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+//                relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
   }
 
   static final int ADD = 0;

--- a/tests/snapshots/src/main/generated/com/airbnb/epoxy/VisibilityState.java
+++ b/tests/snapshots/src/main/generated/com/airbnb/epoxy/VisibilityState.java
@@ -44,7 +44,7 @@ public final class VisibilityState {
   public @interface Visibility {
 //                  ^^^^^^^^^^ definition semanticdb maven . . com/airbnb/epoxy/VisibilityState#Visibility#
 //                             documentation ```java\n@Retention(RetentionPolicy.SOURCE)\n@IntDef({VISIBLE, INVISIBLE, FOCUSED_VISIBLE, UNFOCUSED_VISIBLE, FULL_IMPRESSION_VISIBLE, PARTIAL_IMPRESSION_VISIBLE, PARTIAL_IMPRESSION_INVISIBLE})\npublic @interface Visibility\n```
-//                             relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+//                             relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
   }
 
   /**

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/Annotations.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/Annotations.java
@@ -53,7 +53,7 @@ import static java.lang.annotation.ElementType.*;
 public @interface Annotations {
 //                ^^^^^^^^^^^ definition semanticdb maven . . minimized/Annotations#
 //                            documentation ```java\n@Documented\n@Retention(RetentionPolicy.RUNTIME)\n@Target({CONSTRUCTOR, FIELD, LOCAL_VARIABLE, METHOD, PACKAGE, PARAMETER, TYPE})\npublic @interface Annotations\n```
-//                            relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+//                            relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
 
   String value() default "";
 //^^^^^^ reference semanticdb maven jdk 11 java/lang/String#

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/InnerClasses.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/InnerClasses.java
@@ -72,7 +72,7 @@ public class InnerClasses {
   public @interface InnerAnnotation {
 //                  ^^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/InnerClasses#InnerAnnotation#
 //                                  documentation ```java\npublic @interface InnerAnnotation\n```
-//                                  relationship is_reference is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+//                                  relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
     int value();
 //      ^^^^^ definition semanticdb maven . . minimized/InnerClasses#InnerAnnotation#value().
 //            documentation ```java\npublic abstract int value()\n```


### PR DESCRIPTION
Fixes #678

Previously, doing "Find references" on a symbol with kind `INTERFACE` or `TYPE` returned results for all references to symbols that *implement* that symbol. This bug was particularly noticeable for Kotlin sources because scip-kotlin emits the `TYPE` kind for classes. Now, we no longer emit reference relationships so the implementations only appear in "Find implementation" and not "Find references".

### Test plan

Green CI. See updated snapshots.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
