### PR TITLE
Fix and refactor SBT version logic

### DIFF
--- a/tests/buildTools/src/test/scala/tests/SbtBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/SbtBuildToolSuite.scala
@@ -63,4 +63,4 @@ abstract class SbtBuildToolSuite(sbt: Tool.SBT) extends BaseBuildToolSuite {
 import Tool._
 
 class Sbt_15_BuildToolSuite extends SbtBuildToolSuite(SBT15)
-class Sbt_19_BuildToolSuite extends SbtBuildToolSuite(SBT19)
+class Sbt_110_BuildToolSuite extends SbtBuildToolSuite(SBT110)

--- a/tests/buildTools/src/test/scala/tests/Tool.scala
+++ b/tests/buildTools/src/test/scala/tests/Tool.scala
@@ -45,7 +45,7 @@ object Tool {
       extends Tool("sbt", version, support)
   // See https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#build-tool-compatibility-table
   case object SBT15 extends SBT("1.5.2", atMostJava(17))
-  case object SBT19 extends SBT("1.9.9", noRestrictions)
+  case object SBT110 extends SBT("1.10.0", noRestrictions)
 
   sealed abstract class Scala(version: String, support: JVMSupport)
       extends Tool("scala", version, support)

--- a/tests/unit/src/test/scala/tests/SbtSupportedVersionsSuite.scala
+++ b/tests/unit/src/test/scala/tests/SbtSupportedVersionsSuite.scala
@@ -1,0 +1,47 @@
+package tests
+
+import com.sourcegraph.scip_java.buildtools.SbtBuildTool
+import com.sourcegraph.scip_java.buildtools.SbtVersionParser
+
+class SbtVersionParserSuite extends munit.FunSuite {
+  test("parsing sbt versions") {
+    import SbtVersionParser.{versionSegments => parse}
+    assertEquals(parse("1.9.7"), List(1, 9, 7))
+    assertEquals(parse("1.10.0"), List(1, 10, 0))
+    assertEquals(parse("1.10.0-RC1"), List(1, 10, 0))
+    assertEquals(parse("0.13.17"), List(0, 13, 17))
+    assertEquals(parse("0.13"), List(0, 13))
+  }
+
+  test("supported sbt versions") {
+    import SbtBuildTool.{isSupportedSbtVersion => check}
+
+    def checkSupported(version: String) = {
+      assert(check(version).contains(true), check(version))
+    }
+
+    def checkUnsupported(version: String) = {
+      assert(check(version).contains(false), check(version))
+    }
+
+    def checkFailed(version: String) = {
+      assert(check(version).isLeft, check(version))
+    }
+
+    checkSupported("1.10.0-RC1")
+    checkSupported("0.13.17")
+    checkSupported("1.5.6")
+    checkSupported("1.9.7")
+
+    checkUnsupported("1.0.0-RC1")
+    checkUnsupported("0.13.16")
+    checkUnsupported("1.1.6")
+    checkUnsupported("0.12.15")
+
+    checkFailed("1.0-RC1")
+    checkFailed("0.13")
+    checkFailed("BLA")
+    checkFailed("")
+  }
+
+}


### PR DESCRIPTION
Closes #709 

SBT version parsing logic was broken, so I made it a bit more robust, plus added lots of tests.

### Test plan

- New unit tests
- Bump e2e tests to SBT 1.10 as this was the version breaking everything

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
