### PR TITLE
GRAPH-775 annotation processing fix

### DIFF
--- a/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SignatureFormatter.java
+++ b/scip-semanticdb/src/main/java/com/sourcegraph/scip_semanticdb/SignatureFormatter.java
@@ -468,9 +468,37 @@ public class SignatureFormatter {
       return formatTree(tree.getAssignTree().getLhs())
           + " = "
           + formatTree(tree.getAssignTree().getRhs());
+    } else if (tree.hasUnaryopTree()) {
+      return formatUnaryOperation(tree.getUnaryopTree());
     }
 
     throw new IllegalArgumentException("tree was of unexpected type " + tree);
+  }
+
+  private String formatUnaryOperation(UnaryOperatorTree tree) {
+    String formattedValue = formatTree(tree.getTree());
+    switch (tree.getOp()) {
+      case UNARY_MINUS:
+        return "-" + formattedValue;
+      case UNARY_PLUS:
+        return "-" + formattedValue;
+      case UNARY_POSTFIX_INCREMENT:
+        return formattedValue + "++";
+      case UNARY_POSTFIX_DECREMENT:
+        return formattedValue + "--";
+      case UNARY_PREFIX_DECREMENT:
+        return "--" + formattedValue;
+      case UNARY_PREFIX_INCREMENT:
+        return "++" + formattedValue;
+
+      case UNARY_BITWISE_COMPLEMENT:
+        return "~" + formattedValue;
+      case UNARY_LOGICAL_COMPLEMENT:
+        return "!" + formattedValue;
+    }
+
+    throw new IllegalArgumentException(
+        "unary operation of unexpected type" + tree.getOp().toString());
   }
 
   private String formatConstant(Constant constant) {

--- a/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbBuilders.java
+++ b/semanticdb-java/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbBuilders.java
@@ -146,6 +146,15 @@ public class SemanticdbBuilders {
         .build();
   }
 
+  public static Semanticdb.Tree tree(Semanticdb.UnaryOperatorTree unaryOperatorTree) {
+    return Semanticdb.Tree.newBuilder().setUnaryopTree(unaryOperatorTree).build();
+  }
+
+  public static Semanticdb.UnaryOperatorTree unaryOpTree(
+      Semanticdb.UnaryOperator operator, Semanticdb.Tree rhs) {
+    return Semanticdb.UnaryOperatorTree.newBuilder().setOp(operator).setTree(rhs).build();
+  }
+
   public static Semanticdb.Tree tree(Semanticdb.AssignTree assignTree) {
     return Semanticdb.Tree.newBuilder().setAssignTree(assignTree).build();
   }

--- a/semanticdb-java/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-java/src/main/protobuf/semanticdb.proto
@@ -380,6 +380,7 @@ enum BinaryOperator {
   LESS_THAN_EQUAL = 18;
 }
 
+// https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15
 message UnaryOperatorTree {
   UnaryOperator op = 1;
   Tree tree = 2;

--- a/semanticdb-java/src/main/protobuf/semanticdb.proto
+++ b/semanticdb-java/src/main/protobuf/semanticdb.proto
@@ -297,6 +297,7 @@ message Tree {
     AnnotationTree annotation_tree = 9;
     AssignTree assign_tree = 10;
     BinaryOperatorTree binop_tree = 11;
+    UnaryOperatorTree unaryop_tree = 12;
     // -- OUT OF SPEC -- //
   }
 }
@@ -377,6 +378,22 @@ enum BinaryOperator {
   NOT_EQUAL_TO = 16;
   GREATER_THAN_EQUAL = 17;
   LESS_THAN_EQUAL = 18;
+}
+
+message UnaryOperatorTree {
+  UnaryOperator op = 1;
+  Tree tree = 2;
+}
+
+enum UnaryOperator {
+  UNARY_MINUS = 0;
+  UNARY_PLUS = 1;
+  UNARY_POSTFIX_INCREMENT = 2;
+  UNARY_POSTFIX_DECREMENT = 3;
+  UNARY_PREFIX_DECREMENT = 4;
+  UNARY_PREFIX_INCREMENT = 5;
+  UNARY_BITWISE_COMPLEMENT = 6;
+  UNARY_LOGICAL_COMPLEMENT = 7;
 }
 // -- OUT OF SPEC -- //
 

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTaskListener.java
@@ -83,7 +83,9 @@ public final class SemanticdbTaskListener implements TaskListener {
   // exception, it just prints the location with an empty message.
   private void reportException(Throwable exception, TaskEvent e) {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    exception.printStackTrace(new PrintWriter(baos));
+    PrintWriter pw = new PrintWriter(baos);
+    exception.printStackTrace(pw);
+    pw.close();
     reporter.error(baos.toString(), e.getCompilationUnit(), e.getCompilationUnit());
   }
 

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTrees.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTrees.java
@@ -8,6 +8,7 @@ import com.sun.source.util.TreePath;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.ClassTree;
@@ -78,7 +79,8 @@ public class SemanticdbTrees {
     ArrayList<Semanticdb.Tree> params = new ArrayList<>(annotation.getArguments().size());
 
     for (ExpressionTree param : annotation.getArguments()) {
-      // anecdotally not always AssignmentTree in some situations when a compilation unit can't
+      // anecdotally not always AssignmentTree in some situations when a compilation
+      // unit can't
       // resolve symbols fully
       if (param instanceof AssignmentTree) {
         AssignmentTree assign = (AssignmentTree) param;
@@ -152,6 +154,12 @@ public class SemanticdbTrees {
               annotationParameter(binExpr.getLeftOperand()),
               semanticdbBinaryOperator(expr.getKind()),
               annotationParameter(binExpr.getRightOperand())));
+    } else if (expr instanceof UnaryTree) {
+      UnaryTree unaryExpr = (UnaryTree) expr;
+      return tree(
+          unaryOpTree(
+              semanticdbUnaryOperator(unaryExpr.getKind()),
+              annotationParameter(unaryExpr.getExpression())));
     }
     throw new IllegalArgumentException(
         semanticdbUri
@@ -204,6 +212,17 @@ public class SemanticdbTrees {
       default:
         throw new IllegalStateException(
             semanticdbUri + ": unexpected binary expression operator kind " + kind);
+    }
+  }
+
+  private Semanticdb.UnaryOperator semanticdbUnaryOperator(Tree.Kind kind) {
+    switch (kind) {
+      case UNARY_MINUS:
+        return Semanticdb.UnaryOperator.UNARY_MINUS;
+
+      default:
+        throw new IllegalStateException(
+            semanticdbUri + ": unexpected unary expression operator kind " + kind);
     }
   }
 }

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTrees.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbTrees.java
@@ -220,6 +220,27 @@ public class SemanticdbTrees {
       case UNARY_MINUS:
         return Semanticdb.UnaryOperator.UNARY_MINUS;
 
+      case UNARY_PLUS:
+        return Semanticdb.UnaryOperator.UNARY_PLUS;
+
+      case POSTFIX_INCREMENT:
+        return Semanticdb.UnaryOperator.UNARY_POSTFIX_INCREMENT;
+
+      case POSTFIX_DECREMENT:
+        return Semanticdb.UnaryOperator.UNARY_POSTFIX_DECREMENT;
+
+      case PREFIX_INCREMENT:
+        return Semanticdb.UnaryOperator.UNARY_PREFIX_INCREMENT;
+
+      case PREFIX_DECREMENT:
+        return Semanticdb.UnaryOperator.UNARY_PREFIX_DECREMENT;
+
+      case BITWISE_COMPLEMENT:
+        return Semanticdb.UnaryOperator.UNARY_BITWISE_COMPLEMENT;
+
+      case LOGICAL_COMPLEMENT:
+        return Semanticdb.UnaryOperator.UNARY_LOGICAL_COMPLEMENT;
+
       default:
         throw new IllegalStateException(
             semanticdbUri + ": unexpected unary expression operator kind " + kind);

--- a/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -32,26 +32,6 @@ class MavenBuildToolSuite extends BaseBuildToolSuite {
          |""".stripMargin
   )
 
-  // TODO: find more of a core location to move this to
-  checkBuild(
-    options = "annotation-parameters",
-    original =
-      s"""
-         |/pom.xml
-         |$pomXml
-         |/src/main/java/com/Foo.java
-         |public interface Foo {
-         |    @Bar(-1d)
-         |    double value();
-         |}
-         |/src/main/java/com/Bar.java
-         |@interface Bar {
-         |    double value();
-         |}
-         |""".stripMargin,
-    expectedSemanticdbFiles = 2
-  )
-
   checkBuild(
     "build-command",
     s"""|/pom.xml

--- a/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
+++ b/tests/buildTools/src/test/scala/tests/MavenBuildToolSuite.scala
@@ -32,6 +32,26 @@ class MavenBuildToolSuite extends BaseBuildToolSuite {
          |""".stripMargin
   )
 
+  // TODO: find more of a core location to move this to
+  checkBuild(
+    options = "annotation-parameters",
+    original =
+      s"""
+         |/pom.xml
+         |$pomXml
+         |/src/main/java/com/Foo.java
+         |public interface Foo {
+         |    @Bar(-1d)
+         |    double value();
+         |}
+         |/src/main/java/com/Bar.java
+         |@interface Bar {
+         |    double value();
+         |}
+         |""".stripMargin,
+    expectedSemanticdbFiles = 2
+  )
+
   checkBuild(
     "build-command",
     s"""|/pom.xml

--- a/tests/minimized/src/main/java/minimized/AnnotationParameters.java
+++ b/tests/minimized/src/main/java/minimized/AnnotationParameters.java
@@ -5,6 +5,7 @@ interface Foo {
    double test();
 
    @Bar(~5)
+   @SuppressWarnings(value = "unchecked")
    double test2();
 
    @BarB(!true)

--- a/tests/minimized/src/main/java/minimized/AnnotationParameters.java
+++ b/tests/minimized/src/main/java/minimized/AnnotationParameters.java
@@ -1,0 +1,20 @@
+package minimized;
+
+interface Foo {
+   @Bar(-1d)
+   double test();
+
+   @Bar(~5)
+   double test2();
+
+   @BarB(!true)
+   double test3();
+}
+
+@interface Bar {
+   double value();
+}
+
+@interface BarB {
+   boolean value();
+}

--- a/tests/minimized/src/main/java/minimized/AnnotationParameters.java
+++ b/tests/minimized/src/main/java/minimized/AnnotationParameters.java
@@ -1,5 +1,14 @@
 package minimized;
 
+
+@interface Bar {
+   double value();
+}
+
+@interface BarB {
+   boolean value();
+}
+
 interface Foo {
    @Bar(-1d)
    double test();
@@ -12,10 +21,3 @@ interface Foo {
    double test3();
 }
 
-@interface Bar {
-   double value();
-}
-
-@interface BarB {
-   boolean value();
-}

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AnnotationParameters.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AnnotationParameters.java
@@ -1,0 +1,38 @@
+package minimized;
+
+interface Foo {
+//        ^^^ definition semanticdb maven . . minimized/Foo#
+//            display_name Foo
+//            signature_documentation java interface Foo
+//            kind Interface
+   @Bar(-1d)
+   double test();
+
+   @Bar(~5)
+   double test2();
+
+   @BarB(!true)
+   double test3();
+}
+
+@interface Bar {
+//         ^^^ definition semanticdb maven . . minimized/Bar#
+//             display_name Bar
+//             signature_documentation java @interface Bar
+//             kind Interface
+//             relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+   double value();
+}
+
+@interface BarB {
+//         ^^^^ definition semanticdb maven . . minimized/BarB#
+//              display_name BarB
+//              signature_documentation java @interface BarB
+//              kind Interface
+//              relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+   boolean value();
+//         ^^^^^ definition semanticdb maven . . minimized/BarB#value().
+//               display_name value
+//               signature_documentation java public abstract boolean value()
+//               kind AbstractMethod
+}

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AnnotationParameters.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AnnotationParameters.java
@@ -9,6 +9,7 @@ interface Foo {
    double test();
 
    @Bar(~5)
+   @SuppressWarnings(value = "unchecked")
    double test2();
 
    @BarB(!true)

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AnnotationParameters.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/AnnotationParameters.java
@@ -1,20 +1,5 @@
 package minimized;
 
-interface Foo {
-//        ^^^ definition semanticdb maven . . minimized/Foo#
-//            display_name Foo
-//            signature_documentation java interface Foo
-//            kind Interface
-   @Bar(-1d)
-   double test();
-
-   @Bar(~5)
-   @SuppressWarnings(value = "unchecked")
-   double test2();
-
-   @BarB(!true)
-   double test3();
-}
 
 @interface Bar {
 //         ^^^ definition semanticdb maven . . minimized/Bar#
@@ -32,8 +17,38 @@ interface Foo {
 //              kind Interface
 //              relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
    boolean value();
-//         ^^^^^ definition semanticdb maven . . minimized/BarB#value().
-//               display_name value
-//               signature_documentation java public abstract boolean value()
-//               kind AbstractMethod
 }
+
+interface Foo {
+//        ^^^ definition semanticdb maven . . minimized/Foo#
+//            display_name Foo
+//            signature_documentation java interface Foo
+//            kind Interface
+   @Bar(-1d)
+//  ^^^ reference semanticdb maven . . minimized/Bar#
+   double test();
+//        ^^^^ definition semanticdb maven . . minimized/Foo#test().
+//             display_name test
+//             signature_documentation java @Bar(-1.0)\npublic abstract double test()
+//             kind AbstractMethod
+
+   @Bar(~5)
+//  ^^^ reference semanticdb maven . . minimized/Bar#
+   @SuppressWarnings(value = "unchecked")
+//  ^^^^^^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#
+//                   ^^^^^ reference semanticdb maven jdk 11 java/lang/SuppressWarnings#value().
+   double test2();
+//        ^^^^^ definition semanticdb maven . . minimized/Foo#test2().
+//              display_name test2
+//              signature_documentation java @Bar(~5)\n@SuppressWarnings("unchecked")\npublic abstract double test2()
+//              kind AbstractMethod
+
+   @BarB(!true)
+//  ^^^^ reference semanticdb maven . . minimized/BarB#
+   double test3();
+//        ^^^^^ definition semanticdb maven . . minimized/Foo#test3().
+//              display_name test3
+//              signature_documentation java @BarB(!true)\npublic abstract double test3()
+//              kind AbstractMethod
+}
+

--- a/tests/snapshots/src/main/scala/tests/SaveSnapshots.scala
+++ b/tests/snapshots/src/main/scala/tests/SaveSnapshots.scala
@@ -3,7 +3,19 @@ package tests
 object SaveSnapshots {
   def main(args: Array[String]): Unit = {
     val expectDirectory = tests.snapshots.BuildInfo.snapshotDirectory.toPath
-    SemanticdbJavacSnapshotGenerator
-      .run(SnapshotContext(expectDirectory), new SaveSnapshotHandler)
+    val mapping = Map(
+      "minimized" -> new MinimizedSnapshotScipGenerator(),
+      "library" -> new LibrarySnapshotGenerator()
+    )
+
+    val enabledGenerators =
+      if (args.isEmpty)
+        mapping.values.toList
+      else
+        args.flatMap(mapping.get).toList
+
+    val generator = new AggregateSnapshotGenerator(enabledGenerators)
+
+    generator.run(SnapshotContext(expectDirectory), new SaveSnapshotHandler)
   }
 }


### PR DESCRIPTION
Closes #727

Turns out we weren't handling the unary trees at all, and they're allowed to be values in annotation parameters.

This PR adds support for them.

### Test plan

- New snapshot test

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
