### PR TITLE
Maven plugin for dumping dependencies (cross-repo navigation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,13 @@ jobs:
           mvn clean verify -DskipTests -Dscip-java.version=$SCIP_JAVA_VERSION sourcegraph:sourcegraphDependencies
         working-directory: examples/maven-example
 
-      - run: $SCIP_JAVA_CLI index-semanticdb target/semanticdb-root
+      - run: $SCIP_JAVA_CLI index-semanticdb target/semanticdb-targetroot
+        working-directory: examples/maven-example
+
+      - run: |
+          set -e
+          grep org.hamcrest target/semanticdb-targetroot/dependencies.txt
+          grep $PWD/src/main/java target/semanticdb-targetroot/dependencies.txt
         working-directory: examples/maven-example
 
       - run: du -h index.scip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: yarn global add @bazel/bazelisk
-      - run: sbt cli/pack
-      - run: echo "$PWD/scip-java/target/pack/bin" >> $GITHUB_PATH
+      - run: sbt build
+      - run: echo "out/bin" >> $GITHUB_PATH
       - name: Auto-index scip-java codebase
         run: |
           scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)
@@ -111,4 +111,26 @@ jobs:
       - name: Run sample benchmarks
         run: sbt 'bench/Jmh/run -i 1 -f1 -t1 -foe true'
 
+
+  maven:
+    runs-on: ubuntu-latest
+    name: Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11, 17, 21]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          cache: "sbt"
+          java-version: ${{ matrix.java }}
+
+      - run: sbt build publishM2 dumpScipJavaVersion
+      - run: |
+          mvn clean verify -DskipTests -Dscip-java.version=$(cat VERSION) sourcegraph:sourcegraphDependencies
+      - run: out/bin/scip-java index-semanticdb target/semanticdb-root
+      - run: du -h index.scip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn global add @bazel/bazelisk
       - run: sbt build
-      - run: echo "out/bin" >> $GITHUB_PATH
+      - run: echo "$PWD/out/bin" >> $GITHUB_PATH
       - name: Auto-index scip-java codebase
         run: |
           scip-java index --build-tool=bazel --bazel-scip-java-binary=$(which scip-java)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,15 @@ jobs:
         java: [8, 11, 17, 21]
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           cache: "sbt"
           java-version: ${{ matrix.java }}
-      - name: Main project tests
-        run: sbt test
 
-  benchmarks-test:
-    runs-on: ubuntu-latest
-    name: Benchmark tests
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          cache: "sbt"
-          java-version: 17
-      - name: Run sample benchmarks
-        run: sbt 'bench/Jmh/run -i 1 -f1 -t1 -foe true'
+      - name: Main project tests
+        run: sbt test 
 
   docker_test:
     runs-on: ${{ matrix.os }}
@@ -116,4 +105,10 @@ jobs:
           distribution: "temurin"
           java-version: 17
           cache: "sbt"
+
       - run: sbt checkAll
+
+      - name: Run sample benchmarks
+        run: sbt 'bench/Jmh/run -i 1 -f1 -t1 -foe true'
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
   maven:
     runs-on: ubuntu-latest
-    name: Tests
+    name: Maven tests
     strategy:
       fail-fast: false
       matrix:
@@ -128,9 +128,16 @@ jobs:
           cache: "sbt"
           java-version: ${{ matrix.java }}
 
+
       - run: sbt build publishM2 dumpScipJavaVersion
+
       - run: |
           mvn clean verify -DskipTests -Dscip-java.version=$(cat VERSION) sourcegraph:sourcegraphDependencies
+        working-directory: examples/maven-example
+
       - run: out/bin/scip-java index-semanticdb target/semanticdb-root
+        working-directory: examples/maven-example
+
       - run: du -h index.scip
+        working-directory: examples/maven-example
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,8 @@ jobs:
 
       - run: |
           set -e
-          grep org.hamcrest target/semanticdb-targetroot/dependencies.txt
-          grep $PWD/src/main/java target/semanticdb-targetroot/dependencies.txt
+          grep org.hamcrest target/semanticdb-targetroot/*dependencies.txt
+          grep $PWD/src/main/java target/semanticdb-targetroot/*dependencies.txt
         working-directory: examples/maven-example
 
       - run: du -h index.scip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,16 @@ jobs:
           java-version: ${{ matrix.java }}
 
 
-      - run: sbt build publishM2 dumpScipJavaVersion
+      - run: |
+          sbt build publishM2 publishLocal dumpScipJavaVersion
+          echo "SCIP_JAVA_VERSION=$(cat VERSION)" >> $GITHUB_ENV
+          echo "SCIP_JAVA_CLI=$PWD/out/bin/scip-java" >> $GITHUB_ENV
 
       - run: |
-          mvn clean verify -DskipTests -Dscip-java.version=$(cat VERSION) sourcegraph:sourcegraphDependencies
+          mvn clean verify -DskipTests -Dscip-java.version=$SCIP_JAVA_VERSION sourcegraph:sourcegraphDependencies
         working-directory: examples/maven-example
 
-      - run: out/bin/scip-java index-semanticdb target/semanticdb-root
+      - run: $SCIP_JAVA_CLI index-semanticdb target/semanticdb-root
         working-directory: examples/maven-example
 
       - run: du -h index.scip

--- a/build.sbt
+++ b/build.sbt
@@ -634,13 +634,12 @@ dumpScipJavaVersion := {
   IO.write((ThisBuild / baseDirectory).value / "VERSION", versionValue)
 }
 
-
 lazy val build = taskKey[Unit](
   "Build `scip-java` CLI and place it in the out/bin/scip-java. "
 )
 
 build := {
   val source = (cli / pack).value
-  val newValue = (ThisBuild / baseDirectory).value / "out"
-  IO.copyDirectory(source, newValue) 
+  val destination = (ThisBuild / baseDirectory).value / "out"
+  IO.copyDirectory(source, destination)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,6 @@ import java.util.Properties
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NoStackTrace
 
-ThisBuild / version := sys.env.get("CI").fold("dev")(_ => version.value)
-
 lazy val V =
   new {
     val protobuf = "3.15.6"

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ import java.util.Properties
 import scala.collection.mutable.ListBuffer
 import scala.util.control.NoStackTrace
 
+ThisBuild / version := sys.env.get("CI").fold("dev")(_ => version.value)
+
 lazy val V =
   new {
     val protobuf = "3.15.6"
@@ -205,6 +207,7 @@ lazy val scipProto = project
 lazy val scip = project
   .in(file("scip-semanticdb"))
   .settings(
+    publishMavenStyle := true,
     moduleName := "scip-semanticdb",
     javaToolchainVersion := "8",
     javaOnlySettings,
@@ -213,6 +216,33 @@ lazy val scip = project
     Compile / PB.protocOptions := Seq("--experimental_allow_proto3_optional")
   )
   .dependsOn(semanticdb, scipProto)
+
+lazy val mavenPlugin = project
+  .in(file("maven-plugin"))
+  .settings(
+    moduleName := "maven-plugin",
+    javaToolchainVersion := "8",
+    javaOnlySettings,
+    libraryDependencies ++=
+      Seq(
+        "org.apache.maven" % "maven-plugin-api" % "3.6.3",
+        "org.apache.maven.plugin-tools" % "maven-plugin-annotations" % "3.6.4" %
+          Provided,
+        "org.apache.maven" % "maven-project" % "2.2.1"
+      ),
+    Compile / resourceGenerators +=
+      Def.task {
+        val dir = (Compile / managedResourceDirectories).value.head /
+          "META-INF" / "maven"
+        IO.createDirectory(dir)
+        val file = dir / "plugin.xml"
+        val template = IO.read((Compile / resourceDirectory).value / "META-INF" / "maven" / "plugin.template.xml")
+
+        IO.write(file, template.replace("@VERSION@", version.value))
+
+        Seq(file)
+      }
+  )
 
 lazy val cli = project
   .in(file("scip-java"))

--- a/build.sbt
+++ b/build.sbt
@@ -234,7 +234,10 @@ lazy val mavenPlugin = project
           "META-INF" / "maven"
         IO.createDirectory(dir)
         val file = dir / "plugin.xml"
-        val template = IO.read((Compile / resourceDirectory).value / "META-INF" / "maven" / "plugin.template.xml")
+        val template = IO.read(
+          (Compile / resourceDirectory).value / "META-INF" / "maven" /
+            "plugin.template.xml"
+        )
 
         IO.write(file, template.replace("@VERSION@", version.value))
 
@@ -629,4 +632,15 @@ dumpScipJavaVersion := {
   val versionValue = (cli / version).value
 
   IO.write((ThisBuild / baseDirectory).value / "VERSION", versionValue)
+}
+
+
+lazy val build = taskKey[Unit](
+  "Build `scip-java` CLI and place it in the out/bin/scip-java. "
+)
+
+build := {
+  val source = (cli / pack).value
+  val newValue = (ThisBuild / baseDirectory).value / "out"
+  IO.copyDirectory(source, newValue) 
 }

--- a/docs/manual-configuration.md
+++ b/docs/manual-configuration.md
@@ -156,6 +156,9 @@ index.scip: JSON data
 
 ## Step 5 (optional): Enable cross-repository navigation
 
+Cross-repository navigation is a feature that allows "goto definition" and "find
+references" to show results from multiple repositories.
+
 By default, the `index.scip` file only enables navigation within the local
 repository. You can optionally enable cross-repository navigation by creating
 one of the following files in the SemanticDB _targetroot_ directory (the path in
@@ -192,6 +195,36 @@ one of the following files in the SemanticDB _targetroot_ directory (the path in
   `org.junit.Assert` to Maven coordinates like `junit:junit:4.13.2`. As long as
   your Sourcegraph instance has another repository that defines that symbol, the
   cross-repository navigation should succeed. 
+
+### Maven plugin
+
+To simplify setting up cross-repo navigation for Maven projects, we provide a 
+plugin that can dump the project's dependencies in a format that scip-java understands.
+
+You can either use it directly from commandline:
+
+```
+$ mvn com.sourcegraph:maven-plugin:@STABLE_VERSION@:sourcegraphDependencies
+```
+
+Or add it to your build like any other maven plugin:
+
+```xml
+<plugin>
+    <groupId>com.sourcegraph</groupId>
+    <artifactId>maven-plugin</artifactId>
+    <version>@STABLE_VERSION@</version>
+    <executions>
+        <execution>
+            <goals>
+                <goal>sourcegraphDependencies</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+Which allows you to invoke it by simply running `mvn sourcegraph:sourcegraphDependencies`.
 
 Cross-repository navigation is a feature that allows "goto definition" and "find
 references" to show results from multiple repositories.

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.sourcegraph</groupId>
+    <artifactId>example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>example</name>
+    <!-- FIXME change it to the project's website -->
+    <url>http://www.example.com</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sourcegraph</groupId>
+            <artifactId>semanticdb-javac</artifactId>
+            <version>${scip-java.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+            <plugins>
+                <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                    <configuration>
+                      <compilerArgs>
+                       <arg>-Xplugin:semanticdb -sourceroot:${session.executionRootDirectory} -targetroot:${session.executionRootDirectory}/target/semanticdb-targetroot</arg>
+                      </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.sourcegraph</groupId>
+                    <artifactId>maven-plugin</artifactId>
+                    <version>${scip-java.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>sourcegraphDependencies</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <!-- <configuration> -->
+                    <!--     <scope>test</scope> -->
+                    <!-- </configuration> -->
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/examples/maven-example/pom.xml
+++ b/examples/maven-example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.sourcegraph</groupId>
     <artifactId>example</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <name>example</name>
     <!-- FIXME change it to the project's website -->
@@ -16,6 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <revision>1.0.0-SNAPSHOT</revision>
     </properties>
 
     <dependencies>

--- a/examples/maven-example/src/main/java/App.java
+++ b/examples/maven-example/src/main/java/App.java
@@ -1,0 +1,13 @@
+package test;
+
+/**
+ * Hello world!
+ *
+ */
+public class App 
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/examples/maven-example/src/test/java/AppTest.java
+++ b/examples/maven-example/src/test/java/AppTest.java
@@ -1,0 +1,20 @@
+package test;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}

--- a/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -49,7 +49,6 @@ public class DependencyWriterMojo extends AbstractMojo {
                   + "See here for more details: https://sourcegraph.github.io/scip-java/docs/manual-configuration.html#step-5-optional-enable-cross-repository-navigation\n");
     } else {
       for (Object root : sourceRoots) {
-        getLog().info(root.toString());
         if (root instanceof String) {
           String rootString = (String) root;
           builder.append(

--- a/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -87,8 +87,7 @@ public class DependencyWriterMojo extends AbstractMojo {
         writer.write(builder.toString());
       }
     } catch (IOException e) {
-      throw new MojoFailureException(
-          "Failed to write dependencies to file " + dependenciesFile, e);
+      throw new MojoFailureException("Failed to write dependencies to file " + dependenciesFile, e);
     }
 
     getLog().info("Dependencies were written to " + dependenciesFile.toAbsolutePath());

--- a/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.maven;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -10,8 +9,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-
-import static java.lang.System.*;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -65,13 +62,21 @@ public class DependencyWriterMojo extends AbstractMojo {
     for (Object dep : artifacts) {
       if (dep instanceof Artifact) {
         Artifact artifact = (Artifact) dep;
-        builder.append(
-            String.format(
-                "%s\t%s\t%s\t%s\n",
-                artifact.getGroupId(),
-                artifact.getArtifactId(),
-                artifact.getVersion(),
-                artifact.getFile()));
+        if (artifact.getFile() != null) {
+          builder.append(
+              String.format(
+                  "%s\t%s\t%s\t%s\n",
+                  artifact.getGroupId(),
+                  artifact.getArtifactId(),
+                  artifact.getVersion(),
+                  artifact.getFile()));
+        } else {
+          getLog()
+              .warn(
+                  "Dependency "
+                      + summariseArtifact(artifact)
+                      + " does not have a resolved file, so it won't be added to the dependencies.txt");
+        }
       }
     }
 
@@ -88,5 +93,10 @@ public class DependencyWriterMojo extends AbstractMojo {
     }
 
     getLog().info("Dependencies were written to " + dependenciesFile.toAbsolutePath().toString());
+  }
+
+  private String summariseArtifact(Artifact artifact) {
+    return String.format(
+        "%:%:%", artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
   }
 }

--- a/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -1,0 +1,92 @@
+package com.sourcegraph.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+import static java.lang.System.*;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+
+@Mojo(
+    name = "sourcegraphDependencies",
+    defaultPhase = LifecyclePhase.COMPILE,
+    requiresDependencyResolution = ResolutionScope.COMPILE,
+    requiresProject = true)
+public class DependencyWriterMojo extends AbstractMojo {
+  @Parameter(defaultValue = "${project}", required = true, readonly = true)
+  MavenProject project;
+
+  @Parameter(
+      property = "semanticdb.targetRoot",
+      defaultValue = "${session.executionRootDirectory}/target/semanticdb-targetroot")
+  private String targetRoot;
+
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    Set artifacts = project.getArtifacts();
+    StringBuilder builder = new StringBuilder();
+
+    String groupID = project.getGroupId();
+    String artifactID = project.getArtifactId();
+    String version = project.getVersion();
+    List sourceRoots = project.getCompileSourceRoots();
+
+    if (groupID == null || artifactID == null) {
+      getLog()
+          .warn(
+              "Failed to extract groupID and artifactID from the project.\n"
+                  + "This will not prevent a SCIP index from being created, but the symbols \n"
+                  + "extracted from this project won't be available for cross-repository navigation,\n"
+                  + "as this project doesn't define any Maven coordinates by which it can be referred back to.\n"
+                  + "See here for more details: https://sourcegraph.github.io/scip-java/docs/manual-configuration.html#step-5-optional-enable-cross-repository-navigation\n");
+    } else {
+      for (Object root : sourceRoots) {
+        if (root instanceof String) {
+          String rootString = (String) root;
+          builder.append(
+              String.format("%s\t%s\t%s\t%s\n", groupID, artifactID, version, rootString));
+        }
+      }
+    }
+
+    for (Object dep : artifacts) {
+      if (dep instanceof Artifact) {
+        Artifact artifact = (Artifact) dep;
+        builder.append(
+            String.format(
+                "%s\t%s\t%s\t%s\n",
+                artifact.getGroupId(),
+                artifact.getArtifactId(),
+                artifact.getVersion(),
+                artifact.getFile()));
+      }
+    }
+
+    Path dependenciesFile = Paths.get(targetRoot).resolve("dependencies.txt");
+
+    try {
+      Files.createDirectories(dependenciesFile.getParent());
+      try (BufferedWriter writer = Files.newBufferedWriter(dependenciesFile)) {
+        writer.write(builder.toString());
+      }
+    } catch (IOException e) {
+      throw new MojoFailureException(
+          "Failed to write dependencies to file " + dependenciesFile.toString(), e);
+    }
+
+    getLog().info("Dependencies were written to " + dependenciesFile.toAbsolutePath().toString());
+  }
+}

--- a/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
+++ b/maven-plugin/src/main/java/com/sourcegraph/maven/DependencyWriterMojo.java
@@ -97,6 +97,6 @@ public class DependencyWriterMojo extends AbstractMojo {
 
   private String summariseArtifact(Artifact artifact) {
     return String.format(
-        "%:%:%", artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+        "%s:%s:%s", artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
   }
 }

--- a/maven-plugin/src/main/resources/META-INF/maven/plugin.template.xml
+++ b/maven-plugin/src/main/resources/META-INF/maven/plugin.template.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Written by hand by Anton, send help -->
+
+<plugin>
+  <name>Sourcegraph scip-java Maven plugin</name>
+  <description>A Maven plugin which exports your project's dependencies in a format scip-java can understand</description>
+  <groupId>com.sourcegraph</groupId>
+  <artifactId>maven-plugin</artifactId>
+  <version>@VERSION@</version>
+  <goalPrefix>sourcegraph</goalPrefix>
+  <isolatedRealm>false</isolatedRealm>
+  <inheritedByDefault>true</inheritedByDefault>
+  <requiredJavaVersion>1.8</requiredJavaVersion>
+  <requiredMavenVersion>3.9.5</requiredMavenVersion>
+  <mojos>
+    <mojo>
+      <goal>sourcegraphDependencies</goal>
+      <requiresDirectInvocation>false</requiresDirectInvocation>
+      <requiresProject>true</requiresProject>
+      <requiresReports>false</requiresReports>
+      <aggregator>false</aggregator>
+      <requiresOnline>false</requiresOnline>
+      <inheritedByDefault>true</inheritedByDefault>
+      <phase>generate-resources</phase>
+      <implementation>com.sourcegraph.maven.DependencyWriterMojo</implementation>
+      <language>java</language>
+      <instantiationStrategy>per-lookup</instantiationStrategy>
+      <executionStrategy>once-per-session</executionStrategy>
+      <requiresDependencyResolution>test</requiresDependencyResolution>
+      <threadSafe>true</threadSafe>
+      <parameters>
+        <parameter>
+          <name>project</name>
+          <type>org.apache.maven.project.MavenProject</type>
+          <required>true</required>
+          <editable>false</editable>
+          <description>The maven project.</description>
+        </parameter>
+        <parameter>
+          <name>targetRoot</name>
+          <type>java.lang.String</type>
+          <required>false</required>
+          <editable>true</editable>
+          <description>Location where `dependencies.txt` file will be written (should match the Semanticdb targetroot option)</description>
+        </parameter>
+      </parameters>
+      <configuration>
+        <project implementation="org.apache.maven.project.MavenProject">${project}</project>
+        <targetRoot implementation="java.lang.String">${session.executionRootDirectory}/target/semanticdb-targetroot</targetRoot>
+      </configuration>
+      <requirements>
+      </requirements>
+    </mojo>
+  </mojos>
+  <dependencies>
+  </dependencies>
+</plugin>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.1


### PR DESCRIPTION
GRAPH-796

This PR adds a maven plugin that can be used to produce `dependencies.txt` file necessary for cross-repo navigation on Sourcegraph.

It can be used in a standalone invocation:

```
$ mvn com.sourcegraph:maven-plugin:<VERSION>:sourcegraphDependencies
```

Or added directly to maven build and run with `sourcegraph:sourcegraphDependencies`

```xml
  <plugin>
      <groupId>com.sourcegraph</groupId>
      <artifactId>maven-plugin</artifactId>
      <version>${scip-java.version}</version>
      <executions>
          <execution>
              <goals>
                  <goal>sourcegraphDependencies</goal>
              </goals>
          </execution>
      </executions>
  </plugin>
```


### Test plan

- New maven project is added, and a new CI workflow that indexes it using the plugin

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
