### PR TITLE
Use Gradle project path for unique dependencies.txt path

### DIFF
--- a/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
+++ b/semanticdb-gradle-plugin/src/main/scala/SemanticdbGradlePlugin.scala
@@ -430,6 +430,15 @@ class WriteDependencies extends DefaultTask {
     val deps = List.newBuilder[String]
     val project = getProject()
     val projectName = project.getName()
+    val projectPath = project.getPath().replaceAll("[^a-z0-9A-Z_-]", "_")
+    val dependenciesPath = depsOut.map { path =>
+      val filename = path.getFileName()
+      if (filename.endsWith("dependencies.txt")) {
+        val last = projectPath + "." + path.getFileName().toString()
+        path.getParent().resolve(last)
+      } else
+        path
+    }
 
     val gradle = new GradleVersion(project.getGradle().getGradleVersion())
 
@@ -546,7 +555,7 @@ class WriteDependencies extends DefaultTask {
 
     val dependencies = deps.result().distinct
 
-    depsOut match {
+    dependenciesPath match {
       case None =>
         dependencies.foreach(println)
       case Some(path) =>


### PR DESCRIPTION
The javadoc on `Project#getName` mentions that name is not guaranteed to be unique across the hierarchy, but project path is. So ew use this to write the dependencies to uniquely named files.

See https://github.com/sourcegraph/scip-java/pull/735/files#diff-5dde761886519812960f89108a21668cf947ddb300db91872dafc880f9bd3943R81 where we do the same for Maven.

### Test plan

- N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
