### PR TITLE
docs: Put "cross-repo" optional step before SCIP index generation

### DIFF
--- a/docs/manual-configuration.md
+++ b/docs/manual-configuration.md
@@ -140,21 +140,8 @@ build/semanticdb-targetroot/META-INF/semanticdb/j8/src/main/java/example/Example
 ...
 ```
 
-## Step 4: Generate SCIP index from SemanticDB files
 
-First, install the `scip-java` command-line tool according to the instructions
-in the [getting started guide](getting-started.md).
-
-Next, run the `scip-java index-semanticdb` command to convert SemanticDB files
-into SCIP.
-
-```sh
-❯ scip-java index-semanticdb $TARGETROOT
-❯ file index.scip
-index.scip: JSON data
-```
-
-## Step 5 (optional): Enable cross-repository navigation
+## Step 4 (optional): Enable cross-repository navigation
 
 Cross-repository navigation is a feature that allows "goto definition" and "find
 references" to show results from multiple repositories.
@@ -228,3 +215,18 @@ Which allows you to invoke it by simply running `mvn sourcegraph:sourcegraphDepe
 
 Cross-repository navigation is a feature that allows "goto definition" and "find
 references" to show results from multiple repositories.
+
+## Step 5: Generate SCIP index from SemanticDB files
+
+First, install the `scip-java` command-line tool according to the instructions
+in the [getting started guide](getting-started.md).
+
+Next, run the `scip-java index-semanticdb` command to convert SemanticDB files
+into SCIP.
+
+```sh
+❯ scip-java index-semanticdb $TARGETROOT
+❯ file index.scip
+index.scip: JSON data
+```
+


### PR DESCRIPTION
Move cross-repo configuration before SCIP index generation because the `*dependencies.txt` files need to be present _before_ calling index-semanticdb

### Test plan

- N/A

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
