### PR TITLE
Also support Java 21

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -15,7 +15,7 @@ rm gradle.zip
 mv /opt/gradle/*/* /opt/gradle
 
 # pre-install JDK for all major versions
-for JVM_VERSION in 17 11 8
+for JVM_VERSION in 21 17 11 8
 do 
   coursier java --jvm $JVM_VERSION --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json -- -version
 done

--- a/bin/scip-java-docker-script.sh
+++ b/bin/scip-java-docker-script.sh
@@ -3,7 +3,7 @@
 # version. It assumes that `coursier` is available on the `$PATH` and that the
 # `scip-java` binary is already installed at `/app/scip-java/bin/scip-java`.
 set -eu
-JVM_VERSION="${JVM_VERSION:-17,11,8}"
+JVM_VERSION="${JVM_VERSION:-21,17,11,8}"
 FILE="$PWD/lsif-java.json"
 if test -f "$FILE"; then
 	FROM_CONFIG=$(jq -r '.jvm' "$FILE")
@@ -23,12 +23,11 @@ do
 	if [ "$LAST_CODE" != "0" ]; then
 		echo "Using JVM version '$JVM_VERSION'"
 
-		if [ "$JVM_VERSION" = "17" ]; then
+		if [ "$JVM_VERSION" = "17" ] || [ "$JVM_VERSION" = "21" ]; then
 			export JAVA_OPTS="--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
 		else
 			export JAVA_OPTS=""
 		fi
-
 		eval "$(coursier java --jvm "$JVM_VERSION" --env --jvm-index https://github.com/coursier/jvm-index/blob/master/index.json)"
 
 		java -version

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,6 +54,10 @@ docker run -v $(pwd):/sources --env JVM_VERSION=11 sourcegraph/scip-java:latest 
 
 # Java 17 (default)
 docker run -v $(pwd):/sources --env JVM_VERSION=17 sourcegraph/scip-java:latest scip-java index
+
+# Java 21
+docker run -v $(pwd):/sources --env JVM_VERSION=21 sourcegraph/scip-java:latest scip-java index
+
 ```
 
 ### Java launcher


### PR DESCRIPTION
### Test plan

* run `sbt docker` and ensure image builds
* inspect image to ensure it contains jdk 21

### Errors
Unfortunately i couldn't get this to work, due to what i assume is a local configuration problem. That said, i believe this change should be safe as i exactly copied previous patterns. 

When running `./sbt` then `docker` i received the following
```
...
[info] #9 14.44 Downloaded 66 missing file(s) / 66
[info] #9 15.02 Checking if a JVM is installed
[info] #9 15.02 Found a JVM installed under /opt/java/openjdk.
[info] #9 15.02
[info] #9 15.02 Checking if ~/.local/share/coursier/bin is in PATH
[info] #9 15.02 Should we add ~/.local/share/coursier/bin to your PATH via ~/.profile? [Y/n] Y
[info] #9 15.02
[info] #9 15.02 Checking if the standard Scala applications are installed
  Installed ammonite
  Installed cs
  Installed coursier
No prebuilt binary available at https://github.com/scala/scala3/releases/download/3.5.0/scala3-3.5.0-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.3/scala3-3.4.3-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.2/scala3-3.4.2-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.1/scala3-3.4.1-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.0/scala3-3.4.0-aarch64-pc-linux.tar.gz
[info] #9 ERROR: process "/bin/sh -c ./docker-setup.sh" did not complete successfully: exit code: 1
[info] ------
[info]  > [ 5/12] RUN ./docker-setup.sh:
[info] 11.13 Downloaded 62 missing file(s) / 66
[info] 11.13 Downloaded 63 missing file(s) / 66
[info] 11.42 Downloaded 64 missing file(s) / 66
[info] 11.66 Downloaded 65 missing file(s) / 66
[info] 14.44 Downloaded 66 missing file(s) / 66
[info] 15.02 Checking if a JVM is installed
         Installed ammonite
[info]   Installed cs
No prebuilt binary available at https://github.com/scala/scala3/releases/download/3.5.0/scala3-3.5.0-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.3/scala3-3.4.3-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.2/scala3-3.4.2-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.1/scala3-3.4.1-aarch64-pc-linux.tar.gz, https://github.com/scala/scala3/releases/download/3.4.0/scala3-3.4.0-aarch64-pc-linux.tar.gz
[info] ------
[info] Dockerfile:8
[info] --------------------
[info]    6 |
[info]    7 |     COPY ./bin/docker-setup.sh .
[info]    8 | >>> RUN ./docker-setup.sh
[info]    9 |
[info]   10 |
[info] --------------------
[info] ERROR: failed to solve: process "/bin/sh -c ./docker-setup.sh" did not complete successfully: exit code: 1
[info] View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/k91oxlknsaiwk6i2wjh56yvmr
[error] stack trace is suppressed; run last cli / docker for the full output
[error] (cli / docker) sbtdocker.DockerBuildException: Failed to build Docker image (exit code: 1)
[error] Total time: 82 s (01:22), completed Aug 30, 2024, 3:05:04 PM```