### PR TITLE
Only install coursier and sbt in docker container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,14 @@ jobs:
       - name: Build Dockerised CLI
         run: sbt cli/docker
 
-      - run: |
-
+      - name: Test repos
+        shell: bash
+        run: |
           set -eu
           check_repo() {
             REPO=$1
             mkdir -p .repos/$REPO
-            git clone https://github.com/$REPO.git .repos/$REPO
+            git clone https://github.com/$REPO.git .repos/$REPO && cd .repos/$REPO && git submodule update --init
 
             docker run -v $PWD/.repos/$REPO:/sources -w /sources sourcegraph/scip-java:latest scip-java index
             file .repos/$REPO/index.scip || (echo "$REPO SCIP index doesn't exist!"; exit 1)

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -2,7 +2,7 @@
 set -eux
 curl -fLo /usr/local/bin/coursier https://github.com/coursier/coursier/releases/download/v2.1.5/coursier
 chmod +x /usr/local/bin/coursier
-coursier setup --yes
+coursier setup --yes --apps coursier,sbt
 
 curl -fLo maven.zip https://archive.apache.org/dist/maven/maven-3/3.9.1/binaries/apache-maven-3.9.1-bin.zip 
 unzip -d /opt/maven maven.zip

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import java.nio.file.StandardCopyOption
+import java.nio.file.CopyOption
 import sbtdocker.DockerfileBase
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
@@ -591,19 +593,11 @@ lazy val fatjarPackageSettings = List[Def.Setting[_]](
       oldStrategy(x)
   },
   (Compile / Keys.`package`) := {
-    val slimJar = (Compile / Keys.`package`).value
-    val fatJar = crossTarget.value / (assembly / assemblyJarName).value
-    val _ = assembly.value
-    IO.copyFile(fatJar, slimJar, CopyOptions().withOverwrite(true))
-    slimJar
+    assembly.value
   },
   (Compile / packageBin / packagedArtifact) := {
-    val (art, slimJar) = (Compile / packageBin / packagedArtifact).value
-    val fatJar =
-      new File(crossTarget.value + "/" + (assembly / assemblyJarName).value)
-    val _ = assembly.value
-    IO.copy(List(fatJar -> slimJar), CopyOptions().withOverwrite(true))
-    (art, slimJar)
+    val (artifact, _) = (Compile / packageBin / packagedArtifact).value
+    (artifact, assembly.value)
   },
   pomPostProcess := { node =>
     new RuleTransformer(

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import java.nio.file.StandardCopyOption
-import java.nio.file.CopyOption
 import sbtdocker.DockerfileBase
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}


### PR DESCRIPTION
By default coursier preinstalls some applications which aren't necessary, and can cause issues with local setup.
We limit that to just coursier itself and sbt

### Test plan

- Should be covered by existing tests

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
