### PR TITLE
Bazel aspects: allow sharing source jars and allow empty sourcejars

### DIFF
--- a/examples/bazel-example/src/main/java/srcjar_example/BUILD
+++ b/examples/bazel-example/src/main/java/srcjar_example/BUILD
@@ -4,11 +4,18 @@ genrule(
     cmd = "echo 'package com.testing; public class Bar {};' > Bar.java && jar cf $(@) Bar.java",
 )
 
+genrule(
+    name = "empty-srcjar",
+    outs = ["empty.srcjar"],
+    cmd = "touch test.txt && zip $(@) test.txt && zip -d $(@) test.txt",
+)
+
 java_library(
     name = "testing",
     srcs = [
         "Foo.java",
         ":generated-srcjar",
+        ":empty-srcjar"
     ],
 )
 
@@ -19,4 +26,3 @@ java_library(
         ":generated-srcjar",
     ],
 )
-

--- a/examples/bazel-example/src/main/java/srcjar_example/BUILD
+++ b/examples/bazel-example/src/main/java/srcjar_example/BUILD
@@ -11,3 +11,12 @@ java_library(
         ":generated-srcjar",
     ],
 )
+
+java_library(
+    name = "other_library",
+    srcs = [
+        "Baz.java", # create a new file in source at test/Baz.java, alongside test/Foo.java
+        ":generated-srcjar",
+    ],
+)
+

--- a/examples/bazel-example/src/main/java/srcjar_example/Baz.java
+++ b/examples/bazel-example/src/main/java/srcjar_example/Baz.java
@@ -1,0 +1,7 @@
+package com.testing;
+
+public class Baz {
+    public Bar baz(Bar value) {
+        return value;
+    }
+}

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -70,7 +70,7 @@ def _scip_java(target, ctx):
     output_dir = []
 
     for source_jar in source_jars:
-        dir = ctx.actions.declare_directory("extracted_srcjar/" + source_jar.short_path)
+        dir = ctx.actions.declare_directory(ctx.label.name + "/extracted_srcjar/" + source_jar.short_path)
         output_dir.append(dir)
     
         ctx.actions.run_shell(

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -78,7 +78,7 @@ def _scip_java(target, ctx):
             outputs = [dir],
             mnemonic = "ExtractSourceJars",
             command = """
-                unzip {input_file} -d {output_dir}
+                [ "$(unzip -q -l {input_file} | wc -l)" -eq 0 ] || unzip {input_file} -d {output_dir}
             """.format(
                 output_dir = dir.path,
                 input_file = source_jar.path,


### PR DESCRIPTION
Closes GRAPH-948
Closes GRAPH-949

### Test plan

- Reproducers added to existing cases

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
