### PR TITLE
Don't create a subpath for extracted_srcjar

### DIFF
--- a/examples/bazel-example/src/main/java/srcjar_example/BUILD
+++ b/examples/bazel-example/src/main/java/srcjar_example/BUILD
@@ -26,3 +26,12 @@ java_library(
         ":generated-srcjar",
     ],
 )
+
+java_test(
+    name = "testing_test",
+    srcs = [
+        "Foo.java",
+        ":generated-srcjar",
+    ],
+    test_class = "Foo",
+)

--- a/scip-java/src/main/resources/scip-java/scip_java.bzl
+++ b/scip-java/src/main/resources/scip-java/scip_java.bzl
@@ -9,7 +9,7 @@ different contents.
 This aspect is needed for scip-java to inspect the structure of the Bazel build
 and register actions to index all java_library/java_test/java_binary targets.
 The result of running this aspect is that your bazel-bin/ directory will contain
-many *.scip (https://github.com/sourcegraph/scip) and 
+many *.scip (https://github.com/sourcegraph/scip) and
 *.semanticdb (https://scalameta.org/docs/semanticdb/specification.html) files.
 These files encode information about which symbols are referenced from which
 locations in your source code.
@@ -66,13 +66,13 @@ def _scip_java(target, ctx):
 
     if len(source_files) == 0:
         return None
-    
+
     output_dir = []
 
     for source_jar in source_jars:
-        dir = ctx.actions.declare_directory(ctx.label.name + "/extracted_srcjar/" + source_jar.short_path)
+        dir = ctx.actions.declare_directory(ctx.label.name + ".extracted_srcjar/" + source_jar.short_path)
         output_dir.append(dir)
-    
+
         ctx.actions.run_shell(
             inputs = javac_action.inputs,
             outputs = [dir],
@@ -99,7 +99,7 @@ def _scip_java(target, ctx):
 
     launcher_javac_flags = []
     compiler_javac_flags = []
-    
+
     # In different versions of bazel javac options are either a nested set or a depset or a list...
     javac_options = []
     if hasattr(compilation, "javac_options_list"):
@@ -108,7 +108,7 @@ def _scip_java(target, ctx):
         javac_options = compilation.javac_options
 
     for value in javac_options:
-        # NOTE(Anton): for some bizarre reason I see empty string starting the list of 
+        # NOTE(Anton): for some bizarre reason I see empty string starting the list of
         # javac options - which then gets propagated into the JSON config, and ends up
         # crashing the actual javac invokation.
         if value != "":


### PR DESCRIPTION
Closes GRAPH-988

This avoids an issue where we declare output to be a prefix of the rule's own outputs:

```
testing_test                           (prefix)
testing_test/extracted_srcjar/...      (longer path starting with prefix)
```

Doesn't seem like it was necessary to use nesting, as long as the output name contains both the source jar path, and the task name.

Here's the original error from Bazel (formatting mine, you just now Bazel doesn't output no newlines or structure...):

```
ERROR: 
     output path 'bazel-out/darwin_arm64-fastbuild/bin/src/main/java/srcjar_example/testing_test' 
     (belonging to //src/main/java/srcjar_example:testing_test) 
is a prefix of 
     output path 'bazel-out/darwin_arm64-fastbuild/bin/src/main/java/srcjar_example/testing_test/extracted_srcjar/src/main/java/srcjar_example/sources.srcjar' 
     (belonging to //src/main/java/srcjar_example:testing_test). 

These actions cannot be simultaneously present; please rename one of the output files or build just one of them
```

### Test plan

Added a test case from #757 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
