### PR TITLE
Fix annotated types in new class expression

### DIFF
--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -362,7 +362,8 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
           // More complex case, where the type is annotated: `new @TypeParameters String()`
           else if (node.getIdentifier().getKind() == com.sun.source.tree.Tree.Kind.ANNOTATED_TYPE) {
             AnnotatedTypeTree annotatedTypeTree = (AnnotatedTypeTree) node.getIdentifier();
-            if (annotatedTypeTree.getUnderlyingType().getKind() == com.sun.source.tree.Tree.Kind.IDENTIFIER) {
+            if (annotatedTypeTree.getUnderlyingType().getKind()
+                == com.sun.source.tree.Tree.Kind.IDENTIFIER) {
               IdentifierTree ident = (IdentifierTree) annotatedTypeTree.getUnderlyingType();
               emitSymbolOccurrence(
                   sym, ident, ident.getName(), Role.REFERENCE, CompilerRange.FROM_TEXT_SEARCH);

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -360,10 +360,10 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
                 CompilerRange.FROM_TEXT_SEARCH);
           }
           // More complex case, where the type is annotated: `new @TypeParameters String()`
-          else if (node.getIdentifier().getKind() == com.sun.source.tree.Tree.Kind.ANNOTATED_TYPE) {
+          else if (node.getIdentifier().getKind() == Tree.Kind.ANNOTATED_TYPE) {
             AnnotatedTypeTree annotatedTypeTree = (AnnotatedTypeTree) node.getIdentifier();
-            if (annotatedTypeTree.getUnderlyingType().getKind()
-                == com.sun.source.tree.Tree.Kind.IDENTIFIER) {
+            if (annotatedTypeTree.getUnderlyingType() != null
+                && annotatedTypeTree.getUnderlyingType().getKind() == Tree.Kind.IDENTIFIER) {
               IdentifierTree ident = (IdentifierTree) annotatedTypeTree.getUnderlyingType();
               emitSymbolOccurrence(
                   sym, ident, ident.getName(), Role.REFERENCE, CompilerRange.FROM_TEXT_SEARCH);

--- a/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
+++ b/semanticdb-javac/src/main/java/com/sourcegraph/semanticdb_javac/SemanticdbVisitor.java
@@ -362,8 +362,7 @@ public class SemanticdbVisitor extends TreePathScanner<Void, Void> {
           // More complex case, where the type is annotated: `new @TypeParameters String()`
           else if (node.getIdentifier().getKind() == com.sun.source.tree.Tree.Kind.ANNOTATED_TYPE) {
             AnnotatedTypeTree annotatedTypeTree = (AnnotatedTypeTree) node.getIdentifier();
-            if (annotatedTypeTree.getUnderlyingType().getKind()
-                == com.sun.source.tree.Tree.Kind.IDENTIFIER) {
+            if (annotatedTypeTree.getUnderlyingType().getKind() == com.sun.source.tree.Tree.Kind.IDENTIFIER) {
               IdentifierTree ident = (IdentifierTree) annotatedTypeTree.getUnderlyingType();
               emitSymbolOccurrence(
                   sym, ident, ident.getName(), Role.REFERENCE, CompilerRange.FROM_TEXT_SEARCH);

--- a/tests/minimized/src/main/java/minimized/TypeAnnotations.java
+++ b/tests/minimized/src/main/java/minimized/TypeAnnotations.java
@@ -1,0 +1,16 @@
+package minimized;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE_USE })
+@interface TypeAnnotation {
+    int integer() default 1;
+}
+
+class ClassProcessed<@TypeAnnotation T extends Number> {
+
+    public ClassProcessed() {
+        String s = new @TypeAnnotation String();
+    }
+}

--- a/tests/minimized/src/main/java/minimized/TypeAnnotations.java
+++ b/tests/minimized/src/main/java/minimized/TypeAnnotations.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Target;
     int integer() default 1;
 }
 
+// FIXME(issue: GRAPH-1122): Definition range for T below is incorrect
 class ClassProcessed<@TypeAnnotation T extends Number> {
 
     public ClassProcessed() {

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/TypeAnnotations.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/TypeAnnotations.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
 //              kind AbstractMethod
 }
 
+// FIXME(issue: GRAPH-1122): Definition range for T below is incorrect
 class ClassProcessed<@TypeAnnotation T extends Number> {
 //    ^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/ClassProcessed#
 //                   display_name ClassProcessed

--- a/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/TypeAnnotations.java
+++ b/tests/snapshots/src/main/generated/tests/minimized/src/main/java/minimized/TypeAnnotations.java
@@ -1,0 +1,59 @@
+package minimized;
+
+import java.lang.annotation.ElementType;
+//     ^^^^ reference semanticdb maven . . java/
+//          ^^^^ reference semanticdb maven . . java/lang/
+//               ^^^^^^^^^^ reference semanticdb maven . . java/lang/annotation/
+//                          ^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/annotation/ElementType#
+import java.lang.annotation.Target;
+//     ^^^^ reference semanticdb maven . . java/
+//          ^^^^ reference semanticdb maven . . java/lang/
+//               ^^^^^^^^^^ reference semanticdb maven . . java/lang/annotation/
+//                          ^^^^^^ reference semanticdb maven jdk 11 java/lang/annotation/Target#
+
+@Target({ ElementType.TYPE_USE })
+//^^^^^ reference semanticdb maven jdk 11 java/lang/annotation/Target#
+//        ^^^^^^^^^^^ reference semanticdb maven jdk 11 java/lang/annotation/ElementType#
+//                    ^^^^^^^^ reference semanticdb maven jdk 11 java/lang/annotation/ElementType#TYPE_USE.
+@interface TypeAnnotation {
+//         ^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/TypeAnnotation#
+//                        display_name TypeAnnotation
+//                        signature_documentation java @Target({ElementType.TYPE_USE})\n@interface TypeAnnotation
+//                        kind Interface
+//                        relationship is_implementation semanticdb maven jdk 11 java/lang/annotation/Annotation#
+    int integer() default 1;
+//      ^^^^^^^ definition semanticdb maven . . minimized/TypeAnnotation#integer().
+//              display_name integer
+//              signature_documentation java public abstract int integer()
+//              kind AbstractMethod
+}
+
+class ClassProcessed<@TypeAnnotation T extends Number> {
+//    ^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/ClassProcessed#
+//                   display_name ClassProcessed
+//                   signature_documentation java class ClassProcessed<T extends Number>
+//                   kind Class
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/ClassProcessed#[T]
+//                                                    display_name T
+//                                                    signature_documentation java T extends Number
+//                                                    kind TypeParameter
+//                    ^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/TypeAnnotation#
+//                                             ^^^^^^ reference semanticdb maven jdk 11 java/lang/Number#
+
+    public ClassProcessed() {
+//         ^^^^^^^^^^^^^^ definition semanticdb maven . . minimized/ClassProcessed#`<init>`().
+//                        display_name <init>
+//                        signature_documentation java public ClassProcessed()
+//                        kind Constructor
+        String s = new @TypeAnnotation String();
+//      ^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
+//             ^ definition local 0
+//               display_name s
+//               signature_documentation java String s
+//               enclosing_symbol semanticdb maven . . minimized/ClassProcessed#`<init>`().
+//               kind Variable
+//                      ^^^^^^^^^^^^^^ reference semanticdb maven . . minimized/TypeAnnotation#
+//                                     ^^^^^^ reference semanticdb maven jdk 11 java/lang/String#
+//                                     ^^^^^^ reference semanticdb maven jdk 11 java/lang/String#`<init>`().
+    }
+}


### PR DESCRIPTION
Previously, `new @Bla String()` crashed the plugin.
Now we handle it explicitly.

### Test plan

- New snapshot
