### PR TITLE
chore: fixed dockerignore config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+**/.git
 
 # sbt specific
 .cache


### PR DESCRIPTION
Adding `.git` to .dockerignore which helps to ignore the git directory ending up in the docker image layers.

### Test plan

- CI 🟢 
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
